### PR TITLE
Move integration prompt pages from API Reference to Guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -38,6 +38,15 @@
               "rag_ecommerce",
               "rag_hr"
             ]
+          },
+          {
+            "group": "Integration Prompts",
+            "icon": "code",
+            "pages": [
+              "api-reference/integrate-compress",
+              "api-reference/integrate-extract",
+              "api-reference/integrate-summarize"
+            ]
           }
         ]
       },
@@ -48,24 +57,21 @@
             "group": "Compress",
             "icon": "compress",
             "pages": [
-              "api-reference/compress",
-              "api-reference/integrate-compress"
+              "api-reference/compress"
             ]
           },
           {
             "group": "Extract",
             "icon": "magnifying-glass",
             "pages": [
-              "api-reference/extract",
-              "api-reference/integrate-extract"
+              "api-reference/extract"
             ]
           },
           {
             "group": "Summarize",
             "icon": "text-size",
             "pages": [
-              "api-reference/summarize",
-              "api-reference/integrate-summarize"
+              "api-reference/summarize"
             ]
           }
         ]


### PR DESCRIPTION
## Summary

Moves the three `integrate-*` pages out of API Reference and into a new **Integration Prompts** sub-group under Guides.

- API Reference is now spec-only (compress, extract, summarize)
- Guides gains a new **Integration Prompts** group alongside RAG

## Change

Single edit to `docs.json` — no content changes to any MDX files.

## Test plan

- [ ] Sidebar shows Integration Prompts under Guides, not under API Reference
- [ ] API Reference only contains the three spec pages

https://claude.ai/code/session_01LRthUAtAB5BeMpZh5G36VY