### PR TITLE
Add classify endpoint docs, guides, and integration prompts

### DIFF
--- a/api-reference/classify-overview.mdx
+++ b/api-reference/classify-overview.mdx
@@ -1,0 +1,60 @@
+---
+title: "Classify"
+description: "Score text against user-defined labels and get a probability distribution over those labels."
+---
+
+## What it does
+
+The `/classify` endpoint takes a piece of text and a set of labels you define, then returns a probability score for each label indicating how well the text fits. Scores are softmax-normalised across all labels so they sum to 1.0, and the highest-scoring label is returned as `top_label`.
+
+Each label is scored by running the text against a **rubric** — a yes/no question you write that describes what the label means. The model judges how strongly the text "answers yes" to each question, then normalises the results into a probability distribution.
+
+## When to use it
+
+**You need to route incoming content.** Support tickets, user messages, or documents need to reach the right handler. Classify lets you define your own categories without training a model — just write rubrics that describe each category.
+
+**You're building a moderation layer.** A two-label setup (`spam` / `not spam`, `safe` / `unsafe`) gives you a confidence score you can threshold however your policy requires.
+
+**You need intent detection.** Identify whether an incoming message is a question, complaint, feedback, or cancellation request — and act on it accordingly.
+
+**You want domain tagging at scale.** Tag documents as `medical`, `legal`, `financial`, or any domain relevant to your pipeline, without fine-tuning or labelling training data.
+
+## Common use cases
+
+| Use case | How classify helps |
+|---|---|
+| Support ticket triage | Route tickets to billing, technical, or account teams automatically |
+| Content moderation | Score content against a rubric for spam, toxicity, or policy violations |
+| Intent detection | Identify question / complaint / feedback / cancellation intent |
+| Domain tagging | Label documents by topic for downstream routing or filtering |
+| Lead qualification | Score inbound inquiries against criteria like urgency or deal size |
+| Email categorisation | Sort inbound email into categories without a rules engine |
+
+## How it fits into your workflow
+
+Classify sits between your input source and your routing or handling logic. You pass in the raw text — a ticket, a message, a document — and use the scores to decide what to do next.
+
+```
+[Incoming text] → [POST /classify] → [Route based on top_label or scores]
+```
+
+The response gives you both a `top_label` for simple routing and the full `scores` map if you need finer-grained control (e.g. only act if the top score exceeds a threshold).
+
+## Writing good rubrics
+
+The rubric is the most important part of a classify request. Poor rubrics produce noisy, unreliable scores; well-written rubrics are specific, direct, and independent.
+
+**Rules of thumb:**
+
+- **Be specific.** Vague rubrics produce low-confidence scores.
+- **Frame as a yes/no question.** "Does this text describe X?" outperforms "X content".
+- **Avoid negations.** "Is this NOT about finance?" will confuse the model. Use a positive label instead.
+- **Keep rubrics independent.** Overlapping rubrics (e.g. "Is this medical?" and "Is this about health?") split probability mass unpredictably.
+
+**Examples:**
+
+| Label | Poor rubric | Good rubric |
+|-------|-------------|-------------|
+| `medical` | `medical content` | `Does this text describe a medical condition, symptom, treatment, or health topic?` |
+| `urgent` | `urgent or important` | `Does this text indicate that the sender needs an immediate response or is describing a time-sensitive situation?` |
+| `complaint` | `negative feedback` | `Is this text expressing dissatisfaction, frustration, or a formal complaint about a product or service?` |

--- a/api-reference/classify.mdx
+++ b/api-reference/classify.mdx
@@ -1,0 +1,315 @@
+---
+title: "Classify"
+openapi: "POST /classify"
+description: "Score text against a set of user-defined labels and return a probability distribution."
+---
+
+## Overview
+
+The `/classify` endpoint scores a piece of text against a set of labels you define and returns a softmax-normalised probability distribution. Each label is scored using a **rubric** — a yes/no question that describes what the label means. The label with the highest score is returned as `top_label`.
+
+## Request
+
+<ParamField body="text" type="string" required>
+  The text to classify.
+</ParamField>
+
+<ParamField body="labels" type="array" required>
+  One or more label definitions. Must contain at least one item — sending an empty array returns `422`.
+
+  <Expandable title="Label fields">
+    <ParamField body="name" type="string" required>
+      Short identifier for the label (e.g. `"medical"`, `"billing"`). Used as the key in the `scores` response object.
+    </ParamField>
+
+    <ParamField body="rubric" type="string" required>
+      A yes/no question the model uses to score the label. Phrased so that a "yes" answer means the label applies. See [Writing good rubrics](#writing-good-rubrics) for guidance.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+## Response
+
+<ResponseField name="top_label" type="string">
+  Name of the highest-scoring label.
+</ResponseField>
+
+<ResponseField name="scores" type="object">
+  Map of label name → probability score. All values sum to `1.0`.
+</ResponseField>
+
+<ResponseField name="labels" type="array">
+  Full label list with name, score, and rubric, in the same order as the request.
+
+  <Expandable title="Label fields">
+    <ResponseField name="label" type="string">
+      Label name.
+    </ResponseField>
+
+    <ResponseField name="score" type="number">
+      Softmax-normalised probability (0–1). All scores across all labels sum to 1.0.
+    </ResponseField>
+
+    <ResponseField name="rubric" type="string">
+      The rubric as provided in the request.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+**Score semantics:** Scores are relative probabilities, not absolute confidence values. A score of `0.85` means the model assigned 85% of its probability mass to that label relative to the others. If you need a confidence threshold (e.g. only act if the top score exceeds `0.7`), apply it yourself on the `scores` field.
+
+## Error responses
+
+| Status | Meaning |
+|--------|---------|
+| `422 Unprocessable Entity` | Malformed request body or empty `labels` array. |
+| `502 Bad Gateway` | Model service unavailable or returned an error. |
+
+## Authentication
+
+Include your API key in every request using the `x-api-key` header.
+
+```bash
+-H "x-api-key: <your-api-key>"
+```
+
+## Examples
+
+### Basic topic classification
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST https://api.scaledown.xyz/classify \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "text": "The patient presents with a high fever and difficulty breathing.",
+    "labels": [
+      {
+        "name": "medical",
+        "rubric": "Does this text describe a medical condition, symptom, or health topic?"
+      },
+      {
+        "name": "legal",
+        "rubric": "Does this text describe a legal matter, contract, or regulatory issue?"
+      },
+      {
+        "name": "financial",
+        "rubric": "Does this text describe a financial transaction, investment, or monetary matter?"
+      }
+    ]
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.scaledown.xyz/classify",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "text": "The patient presents with a high fever and difficulty breathing.",
+        "labels": [
+            {
+                "name": "medical",
+                "rubric": "Does this text describe a medical condition, symptom, or health topic?",
+            },
+            {
+                "name": "legal",
+                "rubric": "Does this text describe a legal matter, contract, or regulatory issue?",
+            },
+            {
+                "name": "financial",
+                "rubric": "Does this text describe a financial transaction, investment, or monetary matter?",
+            },
+        ],
+    },
+)
+print(response.json())
+```
+
+```typescript TypeScript
+const response = await fetch("https://api.scaledown.xyz/classify", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": "<your-api-key>",
+  },
+  body: JSON.stringify({
+    text: "The patient presents with a high fever and difficulty breathing.",
+    labels: [
+      {
+        name: "medical",
+        rubric: "Does this text describe a medical condition, symptom, or health topic?",
+      },
+      {
+        name: "legal",
+        rubric: "Does this text describe a legal matter, contract, or regulatory issue?",
+      },
+      {
+        name: "financial",
+        rubric: "Does this text describe a financial transaction, investment, or monetary matter?",
+      },
+    ],
+  }),
+});
+const data = await response.json();
+```
+
+</CodeGroup>
+
+**Response:**
+
+```json
+{
+  "top_label": "medical",
+  "scores": {
+    "medical": 0.887,
+    "legal": 0.071,
+    "financial": 0.042
+  },
+  "labels": [
+    {
+      "label": "medical",
+      "score": 0.887,
+      "rubric": "Does this text describe a medical condition, symptom, or health topic?"
+    },
+    {
+      "label": "legal",
+      "score": 0.071,
+      "rubric": "Does this text describe a legal matter, contract, or regulatory issue?"
+    },
+    {
+      "label": "financial",
+      "score": 0.042,
+      "rubric": "Does this text describe a financial transaction, investment, or monetary matter?"
+    }
+  ]
+}
+```
+
+---
+
+### Support ticket triage
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST https://api.scaledown.xyz/classify \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "text": "I was charged twice for my subscription this month and need a refund immediately.",
+    "labels": [
+      {
+        "name": "billing",
+        "rubric": "Is this text about a billing issue, charge, refund, or payment problem?"
+      },
+      {
+        "name": "technical",
+        "rubric": "Is this text about a technical problem, bug, or product not working correctly?"
+      },
+      {
+        "name": "account",
+        "rubric": "Is this text about account access, login, password, or account settings?"
+      },
+      {
+        "name": "general",
+        "rubric": "Is this a general question or inquiry that does not fit a specific support category?"
+      }
+    ]
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.scaledown.xyz/classify",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "text": "I was charged twice for my subscription this month and need a refund immediately.",
+        "labels": [
+            {"name": "billing",   "rubric": "Is this text about a billing issue, charge, refund, or payment problem?"},
+            {"name": "technical", "rubric": "Is this text about a technical problem, bug, or product not working correctly?"},
+            {"name": "account",   "rubric": "Is this text about account access, login, password, or account settings?"},
+            {"name": "general",   "rubric": "Is this a general question or inquiry that does not fit a specific support category?"},
+        ],
+    },
+)
+print(response.json())
+```
+
+```typescript TypeScript
+const response = await fetch("https://api.scaledown.xyz/classify", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": "<your-api-key>",
+  },
+  body: JSON.stringify({
+    text: "I was charged twice for my subscription this month and need a refund immediately.",
+    labels: [
+      { name: "billing",   rubric: "Is this text about a billing issue, charge, refund, or payment problem?" },
+      { name: "technical", rubric: "Is this text about a technical problem, bug, or product not working correctly?" },
+      { name: "account",   rubric: "Is this text about account access, login, password, or account settings?" },
+      { name: "general",   rubric: "Is this a general question or inquiry that does not fit a specific support category?" },
+    ],
+  }),
+});
+const data = await response.json();
+```
+
+</CodeGroup>
+
+**Response:**
+
+```json
+{
+  "top_label": "billing",
+  "scores": {
+    "billing": 0.921,
+    "technical": 0.034,
+    "account": 0.029,
+    "general": 0.016
+  },
+  "labels": [
+    { "label": "billing",   "score": 0.921, "rubric": "Is this text about a billing issue, charge, refund, or payment problem?" },
+    { "label": "technical", "score": 0.034, "rubric": "Is this text about a technical problem, bug, or product not working correctly?" },
+    { "label": "account",   "score": 0.029, "rubric": "Is this text about account access, login, password, or account settings?" },
+    { "label": "general",   "score": 0.016, "rubric": "Is this a general question or inquiry that does not fit a specific support category?" }
+  ]
+}
+```
+
+## Writing good rubrics
+
+The rubric is the most important part of a classify request. It is phrased as a yes/no question the model uses to score each label. The model scores how strongly the text "answers yes" to the question.
+
+**Rules of thumb:**
+
+- **Be specific.** Vague rubrics produce low-confidence, noisy scores.
+- **Frame as a direct yes/no question.** "Does this text describe X?" works better than "X content".
+- **Avoid negations.** "Is this text NOT about finance?" will confuse the model. Use a positive label instead.
+- **Keep rubrics independent.** Overlapping rubrics (e.g. "Is this medical?" and "Is this about health?") will split probability mass unpredictably.
+
+| Label | Poor rubric | Good rubric |
+|-------|-------------|-------------|
+| `medical` | `medical content` | `Does this text describe a medical condition, symptom, treatment, or health topic?` |
+| `urgent` | `urgent or important` | `Does this text indicate that the sender needs an immediate response or is describing a time-sensitive situation?` |
+| `complaint` | `negative feedback` | `Is this text expressing dissatisfaction, frustration, or a formal complaint about a product or service?` |
+
+## How it works
+
+1. For each label, the model scores the `text` against the label's `rubric`.
+2. Raw scores are real-valued numbers (not probabilities).
+3. Softmax normalisation is applied across all label scores so they sum to 1.0.
+4. The label with the highest normalised score is returned as `top_label`.
+
+The endpoint always returns a winner — even if the model is uncertain. If you need a confidence threshold, apply it yourself on the `scores` field.
+
+## Notes
+
+- There is no hard limit on the number of labels, but performance degrades with very large sets (>20) since each label requires a separate model call.
+- Scores are **relative**, not absolute. A top score of `0.4` in a 10-label request can still be the correct answer — it just means probability mass was spread across many labels.

--- a/api-reference/integrate-classify.mdx
+++ b/api-reference/integrate-classify.mdx
@@ -1,0 +1,266 @@
+---
+title: "Integrate Classify"
+description: "Copy-paste AI prompts to generate integration code for the /classify endpoint."
+---
+
+Copy one of these prompts into Claude, ChatGPT, or any AI assistant to generate integration code for the `/classify` endpoint. Start with the **quick integration** prompt to get something working fast, or use the **production-ready** prompt if you're building for a live environment.
+
+## Prompts
+
+### Quick integration
+
+Paste this prompt to generate a minimal Python function — useful for prototyping or one-off scripts.
+
+```text Quick integration prompt
+Write a Python function `classify_text(text: str, labels: list[dict], api_key: str) -> dict`
+that calls the ScaleDown classify API and returns the full response as a dict.
+
+API details:
+- Endpoint: POST https://api.scaledown.xyz/classify
+- Auth: HTTP header `x-api-key: <your key>`
+- Request body (JSON):
+    {
+      "text": "<text to classify>",
+      "labels": [
+        { "name": "<label name>", "rubric": "<yes/no question>" }
+      ]
+    }
+- Success response (JSON):
+    {
+      "top_label": "medical",
+      "scores": { "medical": 0.887, "legal": 0.071, "financial": 0.042 },
+      "labels": [
+        { "label": "medical", "score": 0.887, "rubric": "..." },
+        ...
+      ]
+    }
+- Error responses: 422 (malformed body or empty labels array), 502 (model service error)
+
+Requirements:
+- Accept the API key as the third parameter.
+- Raise a ValueError with a descriptive message on any non-2xx HTTP response,
+  including the status code and response body in the message.
+- Return the full parsed response dict on success.
+```
+
+### Production-ready
+
+Paste this prompt to generate a fully typed Python service class with error handling, retries, and environment-variable-based configuration.
+
+```text Production-ready prompt
+Write a production-quality Python module for integrating the ScaleDown classify API.
+
+API details:
+- Endpoint: POST https://api.scaledown.xyz/classify
+- Auth: HTTP header `x-api-key: <your key>`
+- Request body (JSON):
+    {
+      "text": "<text to classify>",
+      "labels": [
+        { "name": "<label name>", "rubric": "<yes/no question describing the label>" }
+      ]
+    }
+  Each label must have a "name" (short identifier) and a "rubric" (a yes/no question
+  phrased so that "yes" means the label applies).
+- Success response (JSON):
+    {
+      "top_label": "billing",
+      "scores": { "billing": 0.921, "technical": 0.034, "account": 0.029, "general": 0.016 },
+      "labels": [
+        { "label": "billing", "score": 0.921, "rubric": "..." },
+        ...
+      ]
+    }
+  All scores are softmax-normalised floats that sum to 1.0.
+- Error responses: 422 (malformed body or empty labels), 502 (model service unavailable)
+
+Apply these programming principles:
+
+1. Environment configuration — Load the API key from the environment variable
+   SCALEDOWN_API_KEY. Raise a clear ValueError at construction time if it is missing
+   or empty, with a message that tells the developer exactly what to set.
+
+2. Input type — Define a Label dataclass with fields: name (str), rubric (str).
+
+3. Typed result — Define a ClassifyResult dataclass with fields:
+     top_label (str), scores (dict[str, float]), labels (list[dict])
+
+4. Custom exception — Define a ScaleDownError exception class that carries
+   status_code (int) and message (str), and formats them into the exception message.
+
+5. Single-responsibility client — Implement a ScaleDownClassifyClient class with one
+   public method:
+     classify(text: str, labels: list[Label]) -> ClassifyResult
+   The class owns the requests.Session and sets the auth header once at __init__.
+
+6. Retry with exponential backoff — Inside classify(), on HTTP 502 or any 5xx status,
+   wait 2 s before retry 1, 4 s before retry 2, 8 s before retry 3.
+   Raise ScaleDownError after all three retries are exhausted.
+   Raise ScaleDownError immediately on 422 (not retriable).
+
+7. Type annotations — Add full type annotations to all functions, methods, and fields.
+   No module-level mutable state.
+```
+
+### FastAPI route classifier
+
+Paste this prompt to generate a FastAPI endpoint that classifies incoming text and routes it to a handler based on the top label.
+
+```text FastAPI route classifier prompt
+Write a FastAPI application that accepts a text payload, classifies it using the
+ScaleDown classify API, and routes it to a different handler function based on the
+top-scoring label.
+
+ScaleDown classify API details:
+- Endpoint: POST https://api.scaledown.xyz/classify
+- Auth: HTTP header `x-api-key: <your key>`
+- Request body (JSON):
+    {
+      "text": "<text to classify>",
+      "labels": [
+        { "name": "<label name>", "rubric": "<yes/no question>" }
+      ]
+    }
+- Success response (JSON):
+    {
+      "top_label": "billing",
+      "scores": { "billing": 0.921, "technical": 0.034 },
+      "labels": [ { "label": "billing", "score": 0.921, "rubric": "..." }, ... ]
+    }
+- Error responses: 422 (bad request), 502 (model error)
+
+Requirements:
+
+1. Environment configuration — Load SCALEDOWN_API_KEY from os.environ.
+   Raise RuntimeError with a clear message if the variable is absent.
+
+2. Labels — Use these four support-ticket labels:
+     - billing: "Is this text about a billing issue, charge, refund, or payment problem?"
+     - technical: "Is this text about a technical problem, bug, or product not working correctly?"
+     - account: "Is this text about account access, login, password, or account settings?"
+     - general: "Is this a general question or inquiry that does not fit a specific support category?"
+
+3. Route handlers — Implement four stub async functions:
+     handle_billing(text: str) -> str
+     handle_technical(text: str) -> str
+     handle_account(text: str) -> str
+     handle_general(text: str) -> str
+   Each should return a string like "Routed to billing team: <text>".
+
+4. Confidence threshold — If the top label's score is below 0.5, skip routing and
+   return a 200 response with body: { "routed": false, "reason": "low confidence", "scores": {...} }
+
+5. Main endpoint — POST /triage accepts { "text": str } and returns:
+     { "routed": true, "label": "<top_label>", "score": <float>, "response": "<handler output>" }
+
+6. Error handling — If the ScaleDown API returns a non-2xx response, return a 502
+   response with the error details rather than crashing.
+```
+
+---
+
+## What the production prompt generates
+
+The production-ready prompt instructs the AI to apply seven programming principles. Here is an example of the code it produces:
+
+<Tip>
+**Principles encoded in the production-ready prompt:** environment-variable config, typed Label input, typed result dataclass, custom exception class, single-responsibility service client, retry with exponential backoff, full type annotations.
+</Tip>
+
+<Expandable title="Example output from the production-ready prompt">
+
+```python
+import os
+import time
+import requests
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Label:
+    name: str
+    rubric: str
+
+
+@dataclass
+class ClassifyResult:
+    top_label: str
+    scores: dict[str, float]
+    labels: list[dict[str, Any]]
+
+
+class ScaleDownError(Exception):
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(f"ScaleDown API error {status_code}: {message}")
+        self.status_code = status_code
+        self.message = message
+
+
+class ScaleDownClassifyClient:
+    BASE_URL = "https://api.scaledown.xyz/classify"
+
+    def __init__(self) -> None:
+        api_key = os.environ.get("SCALEDOWN_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "SCALEDOWN_API_KEY environment variable is missing or empty. "
+                "Set it with: export SCALEDOWN_API_KEY=your_key_here"
+            )
+        self._session = requests.Session()
+        self._session.headers.update({"x-api-key": api_key})
+
+    def classify(self, text: str, labels: list[Label]) -> ClassifyResult:
+        payload = {
+            "text": text,
+            "labels": [{"name": l.name, "rubric": l.rubric} for l in labels],
+        }
+        retry_delays = [2, 4, 8]
+        last_error: ScaleDownError | None = None
+
+        for attempt in range(len(retry_delays) + 1):
+            if attempt > 0:
+                time.sleep(retry_delays[attempt - 1])
+
+            response = self._session.post(self.BASE_URL, json=payload)
+
+            if response.ok:
+                data = response.json()
+                return ClassifyResult(
+                    top_label=data["top_label"],
+                    scores=data["scores"],
+                    labels=data["labels"],
+                )
+
+            if response.status_code in {502, 500, 503, 504}:
+                last_error = ScaleDownError(response.status_code, response.text)
+                continue  # retry
+
+            # 422: not retriable
+            raise ScaleDownError(response.status_code, response.text)
+
+        raise last_error  # type: ignore[misc]
+```
+
+Usage:
+
+```python
+import os
+
+os.environ["SCALEDOWN_API_KEY"] = "your_key_here"
+
+client = ScaleDownClassifyClient()
+result = client.classify(
+    text="I was charged twice for my subscription this month.",
+    labels=[
+        Label("billing",   "Is this text about a billing issue, charge, refund, or payment problem?"),
+        Label("technical", "Is this text about a technical problem, bug, or product not working correctly?"),
+        Label("account",   "Is this text about account access, login, password, or account settings?"),
+        Label("general",   "Is this a general question or inquiry that does not fit a specific support category?"),
+    ],
+)
+print(result.top_label)   # "billing"
+print(result.scores)      # {"billing": 0.921, "technical": 0.034, ...}
+```
+
+</Expandable>

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -182,6 +182,85 @@
         }
       }
     },
+    "/classify": {
+      "post": {
+        "summary": "Classify",
+        "description": "Score text against a set of user-defined labels and return a softmax-normalised probability distribution.",
+        "operationId": "classify",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["text", "labels"],
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "The text to classify."
+                  },
+                  "labels": {
+                    "type": "array",
+                    "description": "One or more label definitions. Must contain at least one item.",
+                    "items": {
+                      "type": "object",
+                      "required": ["name", "rubric"],
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Short identifier for the label (e.g. \"medical\", \"billing\"). Used as the key in the scores response object."
+                        },
+                        "rubric": {
+                          "type": "string",
+                          "description": "A yes/no question the model uses to score the label. Phrased so that a \"yes\" answer means the label applies."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful classification",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "top_label": {
+                      "type": "string",
+                      "description": "Name of the highest-scoring label."
+                    },
+                    "scores": {
+                      "type": "object",
+                      "description": "Map of label name to probability score. All values sum to 1.0.",
+                      "additionalProperties": { "type": "number" }
+                    },
+                    "labels": {
+                      "type": "array",
+                      "description": "Full label list with name, score, and rubric, in the same order as the request.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "label": { "type": "string" },
+                          "score": { "type": "number" },
+                          "rubric": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": { "description": "Malformed request body or empty labels array." },
+          "502": { "description": "Model service unavailable or returned an error." }
+        }
+      }
+    },
     "/summarization/abstractive": {
       "post": {
         "summary": "Summarize",

--- a/classify_model_routing.mdx
+++ b/classify_model_routing.mdx
@@ -1,0 +1,308 @@
+---
+title: "LLM Model Routing"
+description: "Use /classify to route requests to different language models based on task complexity and type."
+---
+
+# Guide: LLM Model Routing
+
+**ScaleDown Team** • April 2026 • 8 min read
+
+Not every request needs your most expensive model. A simple factual lookup doesn't need GPT-4o. A one-line code fix doesn't need Claude Opus. But a complex multi-step reasoning problem probably does.
+
+The `/classify` endpoint lets you inspect incoming requests and route them to the right model before you spend tokens on the wrong one. Define labels that describe task types, score each request against them, and dispatch to whichever model handles that task best.
+
+<Tip>
+This guide builds a **model router** that classifies incoming prompts by complexity and type, then dispatches each one to the appropriate LLM. The same pattern works with any set of models — swap in whatever providers and models fit your stack.
+</Tip>
+
+---
+
+## The idea
+
+Every LLM pipeline has a cost/capability tradeoff. Small, fast models are cheap but struggle with complex tasks. Large models handle anything but cost 10–50x more per token. Most pipelines send everything to the large model by default, leaving significant cost savings on the table.
+
+A classifier lets you make that tradeoff explicit:
+
+```mermaid
+graph LR
+    A["Incoming prompt"] --> B["/classify"]
+    B --> C{"top_label"}
+    C -->|simple| D["gpt-4o-mini\n~$0.15 / 1M tokens"]
+    C -->|coding| E["claude-sonnet\n~$3 / 1M tokens"]
+    C -->|reasoning| F["claude-opus\n~$15 / 1M tokens"]
+    C -->|creative| G["gpt-4o\n~$5 / 1M tokens"]
+
+    style A fill:#1e3a5f,stroke:#5b9cf5,stroke-width:2px,color:#bdd7ff
+    style B fill:#263AED,color:#fff,stroke:#5b9cf5,stroke-width:2px
+    style C fill:#1a1a2e,stroke:#5b9cf5,stroke-width:2px,color:#bdd7ff
+    style D fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+    style E fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+    style F fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+    style G fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+```
+
+---
+
+## Define your routing labels
+
+The labels describe the kinds of tasks you want to route differently. Good routing labels are based on what the task *requires* — not what topic it's about.
+
+```python
+LABELS = [
+    {
+        "name": "simple",
+        "rubric": (
+            "Is this a simple, factual, or lookup request that requires a short "
+            "direct answer with no complex reasoning or code?"
+        )
+    },
+    {
+        "name": "coding",
+        "rubric": (
+            "Does this request involve writing, reviewing, debugging, or explaining code?"
+        )
+    },
+    {
+        "name": "reasoning",
+        "rubric": (
+            "Does this request require multi-step reasoning, analysis, planning, "
+            "or synthesising information from multiple sources?"
+        )
+    },
+    {
+        "name": "creative",
+        "rubric": (
+            "Is this a creative writing, brainstorming, or open-ended generative request "
+            "where tone and style matter?"
+        )
+    },
+]
+```
+
+Map each label to a model:
+
+```python
+MODEL_FOR_LABEL = {
+    "simple":    "gpt-4o-mini",
+    "coding":    "claude-sonnet-4-5",
+    "reasoning": "claude-opus-4-6",
+    "creative":  "gpt-4o",
+}
+```
+
+---
+
+## Build the router
+
+<Steps>
+  <Step title="Classify the prompt">
+    ```python
+    import requests
+
+    CLASSIFY_URL = "https://api.scaledown.xyz/classify"
+    SCALEDOWN_HEADERS = {
+        "x-api-key": "YOUR_SCALEDOWN_API_KEY",
+        "Content-Type": "application/json"
+    }
+
+    def pick_model(prompt: str) -> tuple[str, float]:
+        """Return (model_id, confidence) for a given prompt."""
+        response = requests.post(
+            CLASSIFY_URL,
+            headers=SCALEDOWN_HEADERS,
+            json={"text": prompt, "labels": LABELS}
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        label = result["top_label"]
+        score = result["scores"][label]
+        model = MODEL_FOR_LABEL[label]
+        return model, score
+    ```
+  </Step>
+
+  <Step title="Dispatch to the chosen model">
+    ```python
+    import anthropic
+    from openai import OpenAI
+
+    openai_client = OpenAI()
+    anthropic_client = anthropic.Anthropic()
+
+    def call_model(model: str, prompt: str) -> str:
+        if model.startswith("claude"):
+            message = anthropic_client.messages.create(
+                model=model,
+                max_tokens=1024,
+                messages=[{"role": "user", "content": prompt}]
+            )
+            return message.content[0].text
+        else:
+            response = openai_client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}]
+            )
+            return response.choices[0].message.content
+    ```
+  </Step>
+
+  <Step title="Wire them together">
+    ```python
+    CONFIDENCE_THRESHOLD = 0.55
+
+    def route_and_call(prompt: str) -> dict:
+        model, confidence = pick_model(prompt)
+
+        # Fall back to the capable default if the classifier is uncertain
+        if confidence < CONFIDENCE_THRESHOLD:
+            model = "gpt-4o"
+
+        response = call_model(model, prompt)
+        return {
+            "model_used": model,
+            "confidence": confidence,
+            "response": response,
+        }
+    ```
+  </Step>
+</Steps>
+
+---
+
+## Full working example
+
+<Tabs>
+  <Tab title="Python" icon="python">
+    ```python
+    import requests
+    import anthropic
+    from openai import OpenAI
+
+    CLASSIFY_URL = "https://api.scaledown.xyz/classify"
+    SCALEDOWN_HEADERS = {
+        "x-api-key": "YOUR_SCALEDOWN_API_KEY",
+        "Content-Type": "application/json"
+    }
+    CONFIDENCE_THRESHOLD = 0.55
+
+    LABELS = [
+        {"name": "simple",    "rubric": "Is this a simple, factual, or lookup request that requires a short direct answer with no complex reasoning or code?"},
+        {"name": "coding",    "rubric": "Does this request involve writing, reviewing, debugging, or explaining code?"},
+        {"name": "reasoning", "rubric": "Does this request require multi-step reasoning, analysis, planning, or synthesising information from multiple sources?"},
+        {"name": "creative",  "rubric": "Is this a creative writing, brainstorming, or open-ended generative request where tone and style matter?"},
+    ]
+
+    MODEL_FOR_LABEL = {
+        "simple":    "gpt-4o-mini",
+        "coding":    "claude-sonnet-4-5",
+        "reasoning": "claude-opus-4-6",
+        "creative":  "gpt-4o",
+    }
+
+    openai_client = OpenAI()
+    anthropic_client = anthropic.Anthropic()
+
+    def pick_model(prompt: str) -> tuple[str, float]:
+        response = requests.post(
+            CLASSIFY_URL,
+            headers=SCALEDOWN_HEADERS,
+            json={"text": prompt, "labels": LABELS}
+        )
+        response.raise_for_status()
+        result = response.json()
+        label = result["top_label"]
+        score = result["scores"][label]
+        return MODEL_FOR_LABEL[label], score
+
+    def call_model(model: str, prompt: str) -> str:
+        if model.startswith("claude"):
+            msg = anthropic_client.messages.create(
+                model=model,
+                max_tokens=1024,
+                messages=[{"role": "user", "content": prompt}]
+            )
+            return msg.content[0].text
+        else:
+            resp = openai_client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}]
+            )
+            return resp.choices[0].message.content
+
+    def route_and_call(prompt: str) -> dict:
+        model, confidence = pick_model(prompt)
+        if confidence < CONFIDENCE_THRESHOLD:
+            model = "gpt-4o"
+        return {
+            "model_used": model,
+            "confidence": round(confidence, 3),
+            "response": call_model(model, prompt),
+        }
+
+
+    # Test across task types
+    prompts = [
+        "What is the capital of Japan?",
+        "Write a Python function that finds all prime numbers up to n using the Sieve of Eratosthenes.",
+        "A company has three products with different margin profiles. Walk me through how to decide which to prioritise for a sales push.",
+        "Write a short poem about the feeling of debugging code at 2am.",
+    ]
+
+    for prompt in prompts:
+        result = route_and_call(prompt)
+        print(f"Prompt:     {prompt[:70]!r}")
+        print(f"Model used: {result['model_used']} (confidence: {result['confidence']})")
+        print()
+    ```
+
+    **Output:**
+
+    ```
+    Prompt:     'What is the capital of Japan?'
+    Model used: gpt-4o-mini (confidence: 0.923)
+
+    Prompt:     'Write a Python function that finds all prime numbers up to n using'
+    Model used: claude-sonnet-4-5 (confidence: 0.881)
+
+    Prompt:     'A company has three products with different margin profiles. Walk me'
+    Model used: claude-opus-4-6 (confidence: 0.864)
+
+    Prompt:     'Write a short poem about the feeling of debugging code at 2am.'
+    Model used: gpt-4o (confidence: 0.791)
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Cost impact
+
+The savings depend on your traffic mix, but routing even 40% of requests to a cheaper model has a large effect at scale.
+
+| Scenario | Without routing | With routing |
+|---|---|---|
+| 1M requests/day, all to `claude-opus` | ~$15,000/day | — |
+| 50% simple, 30% coding, 20% reasoning | ~$15,000/day | ~$4,800/day |
+| Savings | — | **~68%** |
+
+The classify call itself adds a small latency cost (typically 50–150ms) and a negligible token cost — far less than the savings from routing simple requests away from expensive models.
+
+---
+
+## Tips for production
+
+<CardGroup cols={2}>
+  <Card title="Start with two tiers" icon="layer-group">
+    A simple `fast` / `powerful` split is easier to tune than four labels. Add more tiers once you have data on where the boundaries actually fall in your traffic.
+  </Card>
+  <Card title="Log every routing decision" icon="chart-line">
+    Store `prompt`, `top_label`, `scores`, and `model_used` for every request. After a week you'll see exactly where the classifier is uncertain and whether those requests actually needed a more powerful model.
+  </Card>
+  <Card title="Set a sensible fallback" icon="shield-halved">
+    When confidence is low, fall back to a capable middle-tier model rather than the cheapest or the most expensive. Uncertain inputs rarely need your best model, but they do need something reliable.
+  </Card>
+  <Card title="Overlap is a signal, not a bug" icon="magnifying-glass">
+    If `coding` and `reasoning` frequently score close together, that's telling you something about your traffic — complex coding tasks genuinely sit at the boundary. Consider merging them or adding a dedicated label.
+  </Card>
+</CardGroup>

--- a/classify_support_tickets.mdx
+++ b/classify_support_tickets.mdx
@@ -1,0 +1,289 @@
+---
+title: "Support Ticket Classification"
+description: "Route incoming support tickets to the right handler using the /classify endpoint."
+---
+
+# Guide: Support Ticket Classification
+
+**ScaleDown Team** • April 2026 • 8 min read
+
+Most AI pipelines aren't one-size-fits-all. A customer support system needs different logic for billing questions versus technical bugs. A document processor needs different prompts for legal contracts versus financial reports. Hard-coded keyword rules break down fast. Fine-tuning a classifier requires labelled data you may not have.
+
+The `/classify` endpoint gives you a probability distribution over labels you define in plain language. Use it as the first step in your pipeline to decide which branch to take — no training data, no model fine-tuning, no rules engine.
+
+<Tip>
+This guide builds a **support ticket router** that classifies incoming messages and dispatches them to the appropriate handler. The same pattern works for document routing, intent detection, content moderation, and more.
+</Tip>
+
+---
+
+## How routing with classify works
+
+```mermaid
+graph LR
+    A["Incoming message"] --> B["/classify"]
+    B --> C{"top_label"}
+    C -->|billing| D["Billing handler"]
+    C -->|technical| E["Technical handler"]
+    C -->|account| F["Account handler"]
+    C -->|general| G["General handler"]
+
+    style A fill:#1e3a5f,stroke:#5b9cf5,stroke-width:2px,color:#bdd7ff
+    style B fill:#263AED,color:#fff,stroke:#5b9cf5,stroke-width:2px
+    style C fill:#1a1a2e,stroke:#5b9cf5,stroke-width:2px,color:#bdd7ff
+    style D fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+    style E fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+    style F fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+    style G fill:#117866,color:#fff,stroke:#2dd4a0,stroke-width:2px
+```
+
+The key insight: instead of writing routing logic, you write **rubrics** — yes/no questions that describe each category. The model scores the input text against each rubric and returns a probability distribution. You read `top_label` and route accordingly.
+
+---
+
+## Define your labels
+
+The rubric is what makes routing accurate. Each rubric is a yes/no question phrased so that "yes" means the label applies. Specific, independent rubrics produce clean separation between categories.
+
+```python
+LABELS = [
+    {
+        "name": "billing",
+        "rubric": "Is this text about a billing issue, charge, refund, or payment problem?"
+    },
+    {
+        "name": "technical",
+        "rubric": "Is this text about a technical problem, bug, or product not working correctly?"
+    },
+    {
+        "name": "account",
+        "rubric": "Is this text about account access, login, password, or account settings?"
+    },
+    {
+        "name": "general",
+        "rubric": "Is this a general question or inquiry that does not fit a specific support category?"
+    }
+]
+```
+
+<Info>
+Keep rubrics independent. "Is this about a billing issue?" and "Is this about a payment problem?" overlap — they'll split probability mass between two labels for the same input. Merge them into one rubric or one label.
+</Info>
+
+---
+
+## Build the router
+
+<Steps>
+  <Step title="Set up your client">
+    ```python
+    import requests
+
+    CLASSIFY_URL = "https://api.scaledown.xyz/classify"
+    HEADERS = {
+        "x-api-key": "YOUR_SCALEDOWN_API_KEY",
+        "Content-Type": "application/json"
+    }
+    ```
+  </Step>
+
+  <Step title="Call /classify">
+    ```python
+    def classify_ticket(text: str) -> dict:
+        response = requests.post(
+            CLASSIFY_URL,
+            headers=HEADERS,
+            json={"text": text, "labels": LABELS}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    ticket = "I was charged twice for my subscription this month and need a refund."
+    result = classify_ticket(ticket)
+
+    print(result["top_label"])   # "billing"
+    print(result["scores"])      # {"billing": 0.921, "technical": 0.034, ...}
+    ```
+  </Step>
+
+  <Step title="Route on top_label">
+    ```python
+    def handle_billing(text: str) -> str:
+        return f"[Billing] Escalated to billing team: {text}"
+
+    def handle_technical(text: str) -> str:
+        return f"[Technical] Opened bug report: {text}"
+
+    def handle_account(text: str) -> str:
+        return f"[Account] Sent to account support: {text}"
+
+    def handle_general(text: str) -> str:
+        return f"[General] Added to general queue: {text}"
+
+    HANDLERS = {
+        "billing": handle_billing,
+        "technical": handle_technical,
+        "account": handle_account,
+        "general": handle_general,
+    }
+
+    def route(text: str) -> str:
+        result = classify_ticket(text)
+        label = result["top_label"]
+        return HANDLERS[label](text)
+
+    print(route("I was charged twice for my subscription this month."))
+    # [Billing] Escalated to billing team: I was charged twice...
+    ```
+  </Step>
+
+  <Step title="Add a confidence threshold">
+    The classifier always returns a winner. If you only want to act when the model is confident, check the top score before routing.
+
+    ```python
+    CONFIDENCE_THRESHOLD = 0.6
+
+    def route_with_threshold(text: str) -> str:
+        result = classify_ticket(text)
+        label = result["top_label"]
+        score = result["scores"][label]
+
+        if score < CONFIDENCE_THRESHOLD:
+            return f"[Unrouted] Low confidence ({score:.2f}) — sent to manual review"
+
+        return HANDLERS[label](text)
+
+    print(route_with_threshold("Can you help me?"))
+    # [Unrouted] Low confidence (0.38) — sent to manual review
+    ```
+
+    <Info>
+    A low top score usually means the message is ambiguous or doesn't fit any label well. Routing these to a human or a fallback handler is often the right call.
+    </Info>
+  </Step>
+</Steps>
+
+---
+
+## Full working example
+
+<Tabs>
+  <Tab title="Python" icon="python">
+    ```python
+    import requests
+
+    CLASSIFY_URL = "https://api.scaledown.xyz/classify"
+    HEADERS = {
+        "x-api-key": "YOUR_SCALEDOWN_API_KEY",
+        "Content-Type": "application/json"
+    }
+    CONFIDENCE_THRESHOLD = 0.6
+
+    LABELS = [
+        {"name": "billing",   "rubric": "Is this text about a billing issue, charge, refund, or payment problem?"},
+        {"name": "technical", "rubric": "Is this text about a technical problem, bug, or product not working correctly?"},
+        {"name": "account",   "rubric": "Is this text about account access, login, password, or account settings?"},
+        {"name": "general",   "rubric": "Is this a general question or inquiry that does not fit a specific support category?"},
+    ]
+
+    def classify_ticket(text: str) -> dict:
+        response = requests.post(
+            CLASSIFY_URL,
+            headers=HEADERS,
+            json={"text": text, "labels": LABELS}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def route(text: str) -> dict:
+        result = classify_ticket(text)
+        label = result["top_label"]
+        score = result["scores"][label]
+
+        if score < CONFIDENCE_THRESHOLD:
+            return {"routed": False, "reason": "low_confidence", "scores": result["scores"]}
+
+        return {"routed": True, "label": label, "score": score}
+
+
+    # Test cases
+    tickets = [
+        "I was charged twice for my subscription this month and need a refund.",
+        "The dashboard keeps throwing a 500 error when I try to export my data.",
+        "I can't log in — I think I forgot my password.",
+        "Can you help me?",
+    ]
+
+    for ticket in tickets:
+        outcome = route(ticket)
+        print(f"{ticket[:60]!r}")
+        print(f"  → {outcome}\n")
+    ```
+
+    **Output:**
+
+    ```
+    'I was charged twice for my subscription this month and need'
+      → {'routed': True, 'label': 'billing', 'score': 0.921}
+
+    'The dashboard keeps throwing a 500 error when I try to exp'
+      → {'routed': True, 'label': 'technical', 'score': 0.887}
+
+    "I can't log in — I think I forgot my password."
+      → {'routed': True, 'label': 'account', 'score': 0.934}
+
+    'Can you help me?'
+      → {'routed': False, 'reason': 'low_confidence', 'scores': {'billing': 0.27, 'technical': 0.24, 'account': 0.26, 'general': 0.23}}
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Using scores for more than routing
+
+`top_label` is the simplest way to route, but the full `scores` map gives you more options.
+
+**Escalate when two labels are close.** If `billing` and `technical` are both above 0.3, the ticket might need both teams.
+
+```python
+def needs_escalation(scores: dict, threshold: float = 0.3) -> bool:
+    high_scoring = [label for label, score in scores.items() if score > threshold]
+    return len(high_scoring) > 1
+```
+
+**Log confidence over time.** Consistently low top scores on a particular label signal a rubric that isn't specific enough — or a new category you haven't defined yet.
+
+**Soft routing for LLM prompts.** Instead of hard-switching handlers, use the top label to choose a system prompt:
+
+```python
+SYSTEM_PROMPTS = {
+    "billing":   "You are a billing support specialist. Focus on charges, refunds, and payment issues.",
+    "technical": "You are a technical support engineer. Focus on bugs, errors, and product behaviour.",
+    "account":   "You are an account support specialist. Focus on access, credentials, and settings.",
+    "general":   "You are a helpful support agent. Answer the customer's question clearly and concisely.",
+}
+
+def get_system_prompt(text: str) -> str:
+    result = classify_ticket(text)
+    return SYSTEM_PROMPTS[result["top_label"]]
+```
+
+---
+
+## Tips for production
+
+<CardGroup cols={2}>
+  <Card title="Start with few labels" icon="layer-group">
+    Four to six well-defined labels outperform ten overlapping ones. Add labels only when you see a real category of traffic that isn't being routed correctly.
+  </Card>
+  <Card title="Tune thresholds on real data" icon="sliders">
+    The right confidence threshold depends on your traffic. Log `top_label` and `score` for a week, then look at the score distribution to find a natural cutoff.
+  </Card>
+  <Card title="Test rubrics before deploying" icon="flask">
+    Run a sample of real messages through your labels before going live. If two labels consistently score within 0.05 of each other, your rubrics are too similar — merge or rewrite them.
+  </Card>
+  <Card title="Handle the fallback" icon="shield-halved">
+    Always have a fallback path for low-confidence or unrecognised inputs. Routing uncertain messages to a human or a general-purpose handler is better than forcing a wrong label.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -29,7 +29,8 @@
         "pages": [
           "api-reference/compress-overview",
           "api-reference/extract-overview",
-          "api-reference/summarize-overview"
+          "api-reference/summarize-overview",
+          "api-reference/classify-overview"
         ]
       },
       {
@@ -45,12 +46,21 @@
             ]
           },
           {
+            "group": "Classify",
+            "icon": "route",
+            "pages": [
+              "classify_support_tickets",
+              "classify_model_routing"
+            ]
+          },
+          {
             "group": "Integration Prompts",
             "icon": "code",
             "pages": [
               "api-reference/integrate-compress",
               "api-reference/integrate-extract",
-              "api-reference/integrate-summarize"
+              "api-reference/integrate-summarize",
+              "api-reference/integrate-classify"
             ]
           }
         ]
@@ -77,6 +87,13 @@
             "icon": "text-size",
             "pages": [
               "api-reference/summarize"
+            ]
+          },
+          {
+            "group": "Classify",
+            "icon": "tags",
+            "pages": [
+              "api-reference/classify"
             ]
           }
         ]


### PR DESCRIPTION
- /classify API reference with OpenAPI spec, overview, and integration prompts
- Support ticket classification guide
- LLM model routing guide