### PR TITLE
Update docs for OCR document support, structured extraction, and remo…

### DIFF
--- a/api-reference/classify.mdx
+++ b/api-reference/classify.mdx
@@ -10,8 +10,16 @@ The `/classify` endpoint scores a piece of text against a set of labels you defi
 
 ## Request
 
-<ParamField body="text" type="string" required>
-  The text to classify.
+<ParamField body="text" type="string">
+  The text to classify. Either `text` or `document` must be provided. If both are given, the OCR text is appended after `text`.
+</ParamField>
+
+<ParamField body="document" type="string">
+  A base64-encoded file to classify. Supported formats: JPEG, PNG, TIFF, single-page PDF, multi-page PDF. The file is processed via AWS Textract OCR and the extracted text is used as input. Either `text` or `document` must be provided.
+</ParamField>
+
+<ParamField body="document_mime_type" type="string">
+  MIME type of the document (e.g. `"image/jpeg"`, `"application/pdf"`). Required when `document` is provided.
 </ParamField>
 
 <ParamField body="labels" type="array" required>
@@ -56,13 +64,17 @@ The `/classify` endpoint scores a piece of text against a set of labels you defi
   </Expandable>
 </ResponseField>
 
+<ResponseField name="ocr_text" type="string | null">
+  The raw text extracted from the document via OCR. `null` if no `document` was provided.
+</ResponseField>
+
 **Score semantics:** Scores are relative probabilities, not absolute confidence values. A score of `0.85` means the model assigned 85% of its probability mass to that label relative to the others. If you need a confidence threshold (e.g. only act if the top score exceeds `0.7`), apply it yourself on the `scores` field.
 
 ## Error responses
 
 | Status | Meaning |
 |--------|---------|
-| `422 Unprocessable Entity` | Malformed request body or empty `labels` array. |
+| `422 Unprocessable Entity` | Malformed request body, empty `labels` array, neither `text` nor `document` provided, or OCR failed. |
 | `502 Bad Gateway` | Model service unavailable or returned an error. |
 
 ## Authentication
@@ -282,6 +294,109 @@ const data = await response.json();
   ]
 }
 ```
+
+### Classifying a document
+
+Pass a base64-encoded image or PDF in the `document` field. The OCR text is extracted automatically and classified against your labels. The raw OCR output is returned as `ocr_text`.
+
+<CodeGroup>
+
+```bash cURL
+# Encode a file and classify it
+DOCUMENT=$(base64 -b 0 -i invoice.pdf)
+
+curl -X POST https://api.scaledown.xyz/classify \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "document": "'"$DOCUMENT"'",
+    "document_mime_type": "application/pdf",
+    "labels": [
+      {
+        "name": "invoice",
+        "rubric": "Is this document an invoice or bill requesting payment?"
+      },
+      {
+        "name": "contract",
+        "rubric": "Is this document a legal contract or agreement between parties?"
+      },
+      {
+        "name": "report",
+        "rubric": "Is this document a business or financial report?"
+      }
+    ]
+  }'
+```
+
+```python Python
+import base64
+import requests
+
+with open("invoice.pdf", "rb") as f:
+    document = base64.b64encode(f.read()).decode()
+
+response = requests.post(
+    "https://api.scaledown.xyz/classify",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "document": document,
+        "document_mime_type": "application/pdf",
+        "labels": [
+            {"name": "invoice", "rubric": "Is this document an invoice or bill requesting payment?"},
+            {"name": "contract", "rubric": "Is this document a legal contract or agreement between parties?"},
+            {"name": "report", "rubric": "Is this document a business or financial report?"},
+        ],
+    },
+)
+print(response.json())
+```
+
+```typescript TypeScript
+import fs from "fs";
+
+const document = fs.readFileSync("invoice.pdf").toString("base64");
+
+const response = await fetch("https://api.scaledown.xyz/classify", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": "<your-api-key>",
+  },
+  body: JSON.stringify({
+    document,
+    document_mime_type: "application/pdf",
+    labels: [
+      { name: "invoice", rubric: "Is this document an invoice or bill requesting payment?" },
+      { name: "contract", rubric: "Is this document a legal contract or agreement between parties?" },
+      { name: "report", rubric: "Is this document a business or financial report?" },
+    ],
+  }),
+});
+const data = await response.json();
+```
+
+</CodeGroup>
+
+**Response:**
+
+```json
+{
+  "top_label": "invoice",
+  "scores": {
+    "invoice": 0.941,
+    "contract": 0.037,
+    "report": 0.022
+  },
+  "labels": [
+    { "label": "invoice", "score": 0.941, "rubric": "Is this document an invoice or bill requesting payment?" },
+    { "label": "contract", "score": 0.037, "rubric": "Is this document a legal contract or agreement between parties?" },
+    { "label": "report", "score": 0.022, "rubric": "Is this document a business or financial report?" }
+  ],
+  "ocr_text": "INVOICE\nBill To: Acme Corp\nAmount Due: $4,200.00\nDue Date: June 1, 2025\n..."
+}
+```
+
+---
 
 ## Writing good rubrics
 

--- a/api-reference/extract-overview.mdx
+++ b/api-reference/extract-overview.mdx
@@ -3,10 +3,6 @@ title: "Extract"
 description: "Pull structured data from unstructured text using a schema you define in plain English."
 ---
 
-<Note>
-  **Extract is currently in private preview.** Access is available by invitation. To request early access or get onboarded, [contact us](https://app.reclaim.ai/m/neal-scaledown/25-min).
-</Note>
-
 ## What it does
 
 The `/extract` endpoint runs Named Entity Recognition (NER) over arbitrary text — but instead of a fixed set of entity types (person, place, organization), you define exactly what you're looking for in plain English. The model interprets your descriptions and finds matching spans in the text, returning each one with a confidence score, character offsets, and surrounding context.
@@ -64,3 +60,5 @@ The entity name and description are treated as part of the model's prompt — ho
 | Confidence scores | Varies by model | Always included |
 | Per-entity thresholds | Not typically supported | Supported |
 | Context window | Usually sentence-level | Full document |
+| Structured / nested output | Not supported | Supported via nested object and array schemas |
+| Document / image input | Not supported | Supported via base64 + OCR |

--- a/api-reference/extract.mdx
+++ b/api-reference/extract.mdx
@@ -12,15 +12,25 @@ Every result includes up to 500 characters of surrounding text on each side, so 
 
 ## Request
 
-<ParamField body="text" type="string" required>
-  The input text to extract entities from. Can be a full document, web page content, article, or any plain text string.
+<ParamField body="text" type="string">
+  The input text to extract entities from. Can be a full document, web page content, article, or any plain text string. Either `text` or `document` must be provided. If both are given, the OCR text is appended after `text`.
+</ParamField>
+
+<ParamField body="document" type="string">
+  A base64-encoded file to extract entities from. Supported formats: JPEG, PNG, TIFF, single-page PDF, multi-page PDF. The file is processed via AWS Textract OCR and the extracted text is used as input. Either `text` or `document` must be provided.
+</ParamField>
+
+<ParamField body="document_mime_type" type="string">
+  MIME type of the document (e.g. `"image/jpeg"`, `"application/pdf"`). Required when `document` is provided.
 </ParamField>
 
 <ParamField body="entities" type="object" required>
-  A mapping of entity type names to their definition. Each value can be either:
+  A mapping of entity type names to their definition. Each value can be one of:
 
   - A **plain string** — a description of what to look for
-  - An **object** — with optional `description`, `threshold`, and `top_n` fields that override the global values for that entity type only
+  - An **object** — with optional `description`, `threshold`, and `top_n` fields
+  - A **nested object** — defining a structured sub-schema (object with named fields)
+  - An **array of objects** — defining a repeated structured schema (e.g. a list of line items)
 
   <Expandable title="Entity object fields">
     <ParamField body="description" type="string">
@@ -46,7 +56,7 @@ Every result includes up to 500 characters of surrounding text on each side, so 
 ## Response
 
 <ResponseField name="entities" type="array">
-  List of extracted entities, sorted by confidence descending within each type.
+  List of extracted scalar entities, sorted by confidence descending within each type. For nested or array entity types, values appear in `structured_result` instead.
 
   <Expandable title="Entity object">
     <ResponseField name="text" type="string">
@@ -70,14 +80,21 @@ Every result includes up to 500 characters of surrounding text on each side, so 
   </Expandable>
 </ResponseField>
 
+<ResponseField name="structured_result" type="object | null">
+  Present when any entity in the request uses a nested object or array schema. Contains the full structured extraction result keyed by entity name. Scalar fields from the same request also appear here alongside their nested counterparts. `null` for flat extraction requests.
+</ResponseField>
+
+<ResponseField name="ocr_text" type="string | null">
+  The raw text extracted from the document via OCR. `null` if no `document` was provided.
+</ResponseField>
+
 ## Error responses
 
 | Status | Meaning |
 |--------|---------|
-| `400 Bad Request` | Malformed request body, missing required fields, or empty `entities` map. |
-| `401 Unauthorized` | Missing or invalid `x-api-key`. |
-| `429 Too Many Requests` | Rate limit exceeded. Back off and retry. |
+| `422 Unprocessable Entity` | Malformed request body, neither `text` nor `document` provided, or OCR failed. |
 | `500 Internal Server Error` | Inference service unavailable. |
+| `504 Gateway Timeout` | Extraction request timed out. |
 
 ## Authentication
 
@@ -178,6 +195,277 @@ const data = await response.json();
   ]
 }
 ```
+
+### Extracting from a document
+
+Pass a base64-encoded image or PDF in the `document` field. OCR is performed automatically and the extracted text is used as the input. The raw OCR output is returned as `ocr_text`.
+
+<CodeGroup>
+
+```bash cURL
+DOCUMENT=$(base64 -b 0 -i contract.pdf)
+
+curl -X POST https://api.scaledown.xyz/extract \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "document": "'"$DOCUMENT"'",
+    "document_mime_type": "application/pdf",
+    "entities": {
+      "party_name": "Name of a party to the contract",
+      "effective_date": "The date the contract takes effect",
+      "governing_law": "The jurisdiction or governing law clause"
+    }
+  }'
+```
+
+```python Python
+import base64
+import requests
+
+with open("contract.pdf", "rb") as f:
+    document = base64.b64encode(f.read()).decode()
+
+response = requests.post(
+    "https://api.scaledown.xyz/extract",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "document": document,
+        "document_mime_type": "application/pdf",
+        "entities": {
+            "party_name": "Name of a party to the contract",
+            "effective_date": "The date the contract takes effect",
+            "governing_law": "The jurisdiction or governing law clause",
+        },
+    },
+)
+print(response.json())
+```
+
+```typescript TypeScript
+import fs from "fs";
+
+const document = fs.readFileSync("contract.pdf").toString("base64");
+
+const response = await fetch("https://api.scaledown.xyz/extract", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": "<your-api-key>",
+  },
+  body: JSON.stringify({
+    document,
+    document_mime_type: "application/pdf",
+    entities: {
+      party_name: "Name of a party to the contract",
+      effective_date: "The date the contract takes effect",
+      governing_law: "The jurisdiction or governing law clause",
+    },
+  }),
+});
+const data = await response.json();
+```
+
+</CodeGroup>
+
+---
+
+### Structured (nested) extraction
+
+For more complex documents, you can define nested schemas to extract structured objects or arrays of objects. Use a **nested object** to extract a single structured group of fields, or an **array of objects** to extract a repeated structure such as invoice line items.
+
+The full structured output is returned in the `structured_result` field. Scalar fields in the same request are also included there, alongside any nested values.
+
+**Nested object example — extract a single structured address:**
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST https://api.scaledown.xyz/extract \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "text": "Ship to: Jane Smith, 42 Maple Street, Springfield, IL 62701.",
+    "entities": {
+      "recipient": "The full name of the recipient",
+      "address": {
+        "street": "Street address including number",
+        "city": "City name",
+        "state": "Two-letter state code",
+        "zip": "ZIP or postal code"
+      }
+    }
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.scaledown.xyz/extract",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "text": "Ship to: Jane Smith, 42 Maple Street, Springfield, IL 62701.",
+        "entities": {
+            "recipient": "The full name of the recipient",
+            "address": {
+                "street": "Street address including number",
+                "city": "City name",
+                "state": "Two-letter state code",
+                "zip": "ZIP or postal code",
+            },
+        },
+    },
+)
+print(response.json())
+```
+
+```typescript TypeScript
+const response = await fetch("https://api.scaledown.xyz/extract", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": "<your-api-key>",
+  },
+  body: JSON.stringify({
+    text: "Ship to: Jane Smith, 42 Maple Street, Springfield, IL 62701.",
+    entities: {
+      recipient: "The full name of the recipient",
+      address: {
+        street: "Street address including number",
+        city: "City name",
+        state: "Two-letter state code",
+        zip: "ZIP or postal code",
+      },
+    },
+  }),
+});
+const data = await response.json();
+```
+
+</CodeGroup>
+
+**Response:**
+
+```json
+{
+  "entities": [
+    {
+      "text": "Jane Smith",
+      "type": "recipient",
+      "confidence": 1.0,
+      "start": 9,
+      "end": 19,
+      "context": "Ship to: Jane Smith, 42 Maple Street, Springfield, IL 62701."
+    }
+  ],
+  "structured_result": {
+    "recipient": "Jane Smith",
+    "address": {
+      "street": "42 Maple Street",
+      "city": "Springfield",
+      "state": "IL",
+      "zip": "62701"
+    }
+  },
+  "ocr_text": null
+}
+```
+
+---
+
+**Array schema example — extract invoice line items:**
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST https://api.scaledown.xyz/extract \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "text": "Invoice: 1x Widget A @ $10.00, 3x Widget B @ $5.00, 1x Shipping @ $8.50",
+    "entities": {
+      "vendor": "The name of the vendor or supplier",
+      "line_items": [
+        {
+          "description": "Description or name of the line item",
+          "quantity": "Quantity ordered",
+          "unit_price": "Price per unit"
+        }
+      ]
+    }
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.scaledown.xyz/extract",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "text": "Invoice: 1x Widget A @ $10.00, 3x Widget B @ $5.00, 1x Shipping @ $8.50",
+        "entities": {
+            "vendor": "The name of the vendor or supplier",
+            "line_items": [
+                {
+                    "description": "Description or name of the line item",
+                    "quantity": "Quantity ordered",
+                    "unit_price": "Price per unit",
+                }
+            ],
+        },
+    },
+)
+print(response.json())
+```
+
+```typescript TypeScript
+const response = await fetch("https://api.scaledown.xyz/extract", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": "<your-api-key>",
+  },
+  body: JSON.stringify({
+    text: "Invoice: 1x Widget A @ $10.00, 3x Widget B @ $5.00, 1x Shipping @ $8.50",
+    entities: {
+      vendor: "The name of the vendor or supplier",
+      line_items: [
+        {
+          description: "Description or name of the line item",
+          quantity: "Quantity ordered",
+          unit_price: "Price per unit",
+        },
+      ],
+    },
+  }),
+});
+const data = await response.json();
+```
+
+</CodeGroup>
+
+**Response:**
+
+```json
+{
+  "entities": [],
+  "structured_result": {
+    "vendor": null,
+    "line_items": [
+      { "description": "Widget A", "quantity": "1", "unit_price": "$10.00" },
+      { "description": "Widget B", "quantity": "3", "unit_price": "$5.00" },
+      { "description": "Shipping", "quantity": "1", "unit_price": "$8.50" }
+    ]
+  },
+  "ocr_text": null
+}
+```
+
+When using array schemas, array fields appear only in `structured_result`. The `entities` array contains only scalar fields from the same request that could be matched to a span in the text.
+
+---
 
 ### With per-entity overrides
 

--- a/api-reference/integrate-classify.mdx
+++ b/api-reference/integrate-classify.mdx
@@ -12,7 +12,7 @@ Copy one of these prompts into Claude, ChatGPT, or any AI assistant to generate 
 Paste this prompt to generate a minimal Python function — useful for prototyping or one-off scripts.
 
 ```text Quick integration prompt
-Write a Python function `classify_text(text: str, labels: list[dict], api_key: str) -> dict`
+Write a Python function `classify_text(payload: dict, labels: list[dict], api_key: str) -> dict`
 that calls the ScaleDown classify API and returns the full response as a dict.
 
 API details:
@@ -20,11 +20,15 @@ API details:
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<text to classify>",
+      "text": "<text to classify>",              // optional if document is provided
+      "document": "<base64-encoded file>",        // optional; image or PDF
+      "document_mime_type": "image/jpeg",         // required when document is set
       "labels": [
         { "name": "<label name>", "rubric": "<yes/no question>" }
       ]
     }
+  Either "text" or "document" must be provided. If both are given, OCR text is appended
+  after the plain text before classification.
 - Success response (JSON):
     {
       "top_label": "medical",
@@ -32,11 +36,15 @@ API details:
       "labels": [
         { "label": "medical", "score": 0.887, "rubric": "..." },
         ...
-      ]
+      ],
+      "ocr_text": null    // populated when a document was processed
     }
-- Error responses: 422 (malformed body or empty labels array), 502 (model service error)
+- Error responses: 422 (malformed body, neither text nor document, empty labels array,
+  or OCR failure), 500 (server error), 504 (timeout)
 
 Requirements:
+- The payload parameter is a dict that may contain "text", "document", and
+  "document_mime_type" keys. Pass it through to the request body along with "labels".
 - Accept the API key as the third parameter.
 - Raise a ValueError with a descriptive message on any non-2xx HTTP response,
   including the status code and response body in the message.
@@ -55,11 +63,15 @@ API details:
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<text to classify>",
+      "text": "<text to classify>",              // optional if document is provided
+      "document": "<base64-encoded file>",        // optional; image or PDF
+      "document_mime_type": "image/jpeg",         // required when document is set
       "labels": [
         { "name": "<label name>", "rubric": "<yes/no question describing the label>" }
       ]
     }
+  Either "text" or "document" must be provided. If both are given, OCR text is appended
+  after the plain text before classification.
   Each label must have a "name" (short identifier) and a "rubric" (a yes/no question
   phrased so that "yes" means the label applies).
 - Success response (JSON):
@@ -69,10 +81,12 @@ API details:
       "labels": [
         { "label": "billing", "score": 0.921, "rubric": "..." },
         ...
-      ]
+      ],
+      "ocr_text": "<raw OCR text>" | null    // populated when a document was processed
     }
   All scores are softmax-normalised floats that sum to 1.0.
-- Error responses: 422 (malformed body or empty labels), 502 (model service unavailable)
+- Error responses: 422 (malformed body, neither text nor document, empty labels, or OCR
+  failure), 500 (server error), 504 (timeout)
 
 Apply these programming principles:
 
@@ -83,17 +97,24 @@ Apply these programming principles:
 2. Input type — Define a Label dataclass with fields: name (str), rubric (str).
 
 3. Typed result — Define a ClassifyResult dataclass with fields:
-     top_label (str), scores (dict[str, float]), labels (list[dict])
+     top_label (str), scores (dict[str, float]), labels (list[dict]),
+     ocr_text (str | None)
 
 4. Custom exception — Define a ScaleDownError exception class that carries
    status_code (int) and message (str), and formats them into the exception message.
 
 5. Single-responsibility client — Implement a ScaleDownClassifyClient class with one
    public method:
-     classify(text: str, labels: list[Label]) -> ClassifyResult
+     classify(
+       labels: list[Label],
+       text: str | None = None,
+       document: str | None = None,
+       document_mime_type: str | None = None,
+     ) -> ClassifyResult
    The class owns the requests.Session and sets the auth header once at __init__.
+   Omit "document" and "document_mime_type" from the payload when they are None.
 
-6. Retry with exponential backoff — Inside classify(), on HTTP 502 or any 5xx status,
+6. Retry with exponential backoff — Inside classify(), on HTTP 5xx or 504 status,
    wait 2 s before retry 1, 4 s before retry 2, 8 s before retry 3.
    Raise ScaleDownError after all three retries are exhausted.
    Raise ScaleDownError immediately on 422 (not retriable).
@@ -107,8 +128,8 @@ Apply these programming principles:
 Paste this prompt to generate a FastAPI endpoint that classifies incoming text and routes it to a handler based on the top label.
 
 ```text FastAPI route classifier prompt
-Write a FastAPI application that accepts a text payload, classifies it using the
-ScaleDown classify API, and routes it to a different handler function based on the
+Write a FastAPI application that accepts a text or document payload, classifies it using
+the ScaleDown classify API, and routes it to a different handler function based on the
 top-scoring label.
 
 ScaleDown classify API details:
@@ -116,18 +137,23 @@ ScaleDown classify API details:
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<text to classify>",
+      "text": "<text to classify>",              // optional if document is provided
+      "document": "<base64-encoded file>",        // optional; image or PDF
+      "document_mime_type": "image/jpeg",         // required when document is set
       "labels": [
         { "name": "<label name>", "rubric": "<yes/no question>" }
       ]
     }
+  Either "text" or "document" must be provided.
 - Success response (JSON):
     {
       "top_label": "billing",
       "scores": { "billing": 0.921, "technical": 0.034 },
-      "labels": [ { "label": "billing", "score": 0.921, "rubric": "..." }, ... ]
+      "labels": [ { "label": "billing", "score": 0.921, "rubric": "..." }, ... ],
+      "ocr_text": "<raw OCR text>" | null
     }
-- Error responses: 422 (bad request), 502 (model error)
+- Error responses: 422 (bad request, neither text nor document, or OCR failure),
+  500 (server error), 504 (timeout)
 
 Requirements:
 
@@ -150,7 +176,8 @@ Requirements:
 4. Confidence threshold — If the top label's score is below 0.5, skip routing and
    return a 200 response with body: { "routed": false, "reason": "low confidence", "scores": {...} }
 
-5. Main endpoint — POST /triage accepts { "text": str } and returns:
+5. Main endpoint — POST /triage accepts { "text": str | None, "document": str | None,
+   "document_mime_type": str | None } and returns:
      { "routed": true, "label": "<top_label>", "score": <float>, "response": "<handler output>" }
 
 6. Error handling — If the ScaleDown API returns a non-2xx response, return a 502
@@ -188,6 +215,7 @@ class ClassifyResult:
     top_label: str
     scores: dict[str, float]
     labels: list[dict[str, Any]]
+    ocr_text: str | None
 
 
 class ScaleDownError(Exception):
@@ -210,11 +238,21 @@ class ScaleDownClassifyClient:
         self._session = requests.Session()
         self._session.headers.update({"x-api-key": api_key})
 
-    def classify(self, text: str, labels: list[Label]) -> ClassifyResult:
-        payload = {
-            "text": text,
-            "labels": [{"name": l.name, "rubric": l.rubric} for l in labels],
-        }
+    def classify(
+        self,
+        labels: list[Label],
+        text: str | None = None,
+        document: str | None = None,
+        document_mime_type: str | None = None,
+    ) -> ClassifyResult:
+        payload: dict = {"labels": [{"name": l.name, "rubric": l.rubric} for l in labels]}
+        if text is not None:
+            payload["text"] = text
+        if document is not None:
+            payload["document"] = document
+        if document_mime_type is not None:
+            payload["document_mime_type"] = document_mime_type
+
         retry_delays = [2, 4, 8]
         last_error: ScaleDownError | None = None
 
@@ -230,9 +268,10 @@ class ScaleDownClassifyClient:
                     top_label=data["top_label"],
                     scores=data["scores"],
                     labels=data["labels"],
+                    ocr_text=data.get("ocr_text"),
                 )
 
-            if response.status_code in {502, 500, 503, 504}:
+            if response.status_code in {500, 503, 504}:
                 last_error = ScaleDownError(response.status_code, response.text)
                 continue  # retry
 
@@ -251,13 +290,13 @@ os.environ["SCALEDOWN_API_KEY"] = "your_key_here"
 
 client = ScaleDownClassifyClient()
 result = client.classify(
-    text="I was charged twice for my subscription this month.",
     labels=[
         Label("billing",   "Is this text about a billing issue, charge, refund, or payment problem?"),
         Label("technical", "Is this text about a technical problem, bug, or product not working correctly?"),
         Label("account",   "Is this text about account access, login, password, or account settings?"),
         Label("general",   "Is this a general question or inquiry that does not fit a specific support category?"),
     ],
+    text="I was charged twice for my subscription this month.",
 )
 print(result.top_label)   # "billing"
 print(result.scores)      # {"billing": 0.921, "technical": 0.034, ...}

--- a/api-reference/integrate-extract.mdx
+++ b/api-reference/integrate-extract.mdx
@@ -3,10 +3,6 @@ title: "Integrate Extract"
 description: "Copy-paste AI prompts to generate integration code for the /extract endpoint."
 ---
 
-<Note>
-  **Extract is currently in private preview.** [Request access](https://app.reclaim.ai/m/neal-scaledown/25-min) before integrating.
-</Note>
-
 Copy one of these prompts into Claude, ChatGPT, or any AI assistant to generate integration code for the `/extract` endpoint. Start with the **quick integration** prompt to get something working fast, or use the **production-ready** prompt if you're building for a live environment.
 
 ## Prompts
@@ -17,49 +13,57 @@ Paste this prompt to generate a minimal TypeScript function — useful for proto
 
 ```text Quick integration prompt
 Write a TypeScript async function `extractEntities` that calls the ScaleDown entity
-extraction API and returns the list of extracted entities.
+extraction API and returns the parsed response.
 
 API details:
 - Endpoint: POST https://api.scaledown.xyz/extract
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<the document or passage to search>",
+      "text": "<the document or passage to search>",       // optional if document is provided
+      "document": "<base64-encoded file>",                 // optional; image or PDF
+      "document_mime_type": "image/jpeg",                  // required when document is set
       "entities": {
         "<EntityTypeName>": "<plain English description of what to look for>"
+        // values can also be nested objects or arrays — see structured extraction below
       }
     }
-  The keys in "entities" are names you choose (e.g. "Name", "Email", "Company").
-  The values are descriptions of what each key should match.
+  Either "text" or "document" must be provided. If both are given, OCR text is appended
+  after the plain text before extraction. The keys in "entities" are names you choose
+  (e.g. "Name", "Email", "Company"). The values are descriptions of what each key should match.
 - Success response (JSON):
     {
       "entities": [
         {
           "text": "<the exact matched span from the input>",
           "type": "<EntityTypeName matching a key you defined>",
-          "confidence": 0.994,
+          "confidence": 1.0,
           "start": 0,
           "end": 10,
           "context": "<up to 500 characters of surrounding text on each side>"
         }
-      ]
+      ],
+      "structured_result": null,   // populated when nested/array entity schemas are used
+      "ocr_text": null             // populated when a document was processed
     }
-- Error responses: 400 (bad body or empty entities map), 401 (invalid key),
-  429 (rate limited), 500 (server error)
+- Error responses: 422 (bad body, neither text nor document, or OCR failure),
+  500 (server error), 504 (timeout)
 
 Function signature:
   extractEntities(
-    text: string,
-    entitySchema: Record<string, string>,
+    payload: { text?: string; document?: string; document_mime_type?: string;
+               entities: Record<string, unknown> },
     apiKey: string
-  ): Promise<Array<{ text: string; type: string; confidence: number;
-                      start: number; end: number; context: string }>>
+  ): Promise<{ entities: Array<{ text: string; type: string; confidence: number;
+                                 start: number; end: number; context: string }>;
+               structured_result: Record<string, unknown> | null;
+               ocr_text: string | null }>
 
 Requirements:
 - Use the native fetch API (Node 18+).
 - Throw an Error that includes the HTTP status code and response body text on
   any non-2xx response.
-- Return the entities array directly on success.
+- Return the full parsed response on success.
 ```
 
 ### Production-ready
@@ -75,7 +79,9 @@ API details:
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<document or passage to search>",
+      "text": "<document or passage to search>",          // optional if document is provided
+      "document": "<base64-encoded file>",                // optional; image or PDF
+      "document_mime_type": "application/pdf",            // required when document is set
       "entities": {
         "<TypeName>": "<description string>"
           | {
@@ -83,26 +89,36 @@ API details:
               "threshold": 0.0–1.0,  // optional, overrides global threshold for this type
               "top_n": number        // optional, max results for this type; 0 = unlimited
             }
+          | { "<field>": "<description>", ... }           // nested object schema
+          | [{ "<field>": "<description>", ... }]         // array-of-objects schema
       },
       "threshold": 0.5,  // optional global confidence cutoff, default 0.5
       "top_n": 0         // optional global max results per type, default 0 (unlimited)
     }
+  Either "text" or "document" must be provided. If both are given, the OCR text is
+  appended after the plain text before extraction.
 - Success response (JSON):
     {
       "entities": [
         {
           "text": "<matched span>",
           "type": "<TypeName>",
-          "confidence": 0.994,
+          "confidence": 1.0,
           "start": 0,
           "end": 10,
           "context": "<up to 500 chars of surrounding text on each side>"
         }
-      ]
+      ],
+      "structured_result": {        // present when nested/array schemas are used
+        "<TypeName>": <value> | { ... } | [ ... ] | null
+      } | null,
+      "ocr_text": "<raw OCR text>" | null
     }
-  Results within each type are ranked by confidence descending before top_n is applied.
-- Error responses: 400 (malformed body or empty entities map), 401 (missing/invalid key),
-  429 (rate limit exceeded), 500 (server error)
+  Scalar entity results are in "entities"; nested object and array results are in
+  "structured_result". Results within each scalar type are ranked by confidence
+  descending before top_n is applied.
+- Error responses: 422 (malformed body, neither text nor document, or OCR failure),
+  500 (server error), 504 (timeout)
 
 Apply these programming principles:
 
@@ -111,11 +127,18 @@ Apply these programming principles:
    with a message that tells the developer exactly which variable to set.
 
 2. TypeScript interfaces — Define the following:
-     EntityDefinition: string | { description: string; threshold?: number; top_n?: number }
+     EntityDefinition: string
+       | { description: string; threshold?: number; top_n?: number }
+       | Record<string, unknown>
+       | Array<Record<string, unknown>>
      ExtractOptions: { threshold?: number; top_n?: number }
      ExtractedEntity: { text: string; type: string; confidence: number;
                         start: number; end: number; context: string }
-     ExtractResult: { entities: ExtractedEntity[] }
+     ExtractResult: {
+       entities: ExtractedEntity[];
+       structured_result: Record<string, unknown> | null;
+       ocr_text: string | null;
+     }
 
 3. Custom error class — Define ScaleDownError extending Error with fields
    status: number and body: string, setting name = "ScaleDownError".
@@ -123,16 +146,20 @@ Apply these programming principles:
 4. Single-responsibility client — Implement a ScaleDownExtractClient class with one
    public async method:
      extract(
-       text: string,
-       entitySchema: Record<string, EntityDefinition>,
+       payload: {
+         text?: string;
+         document?: string;
+         document_mime_type?: string;
+         entities: Record<string, EntityDefinition>;
+       },
        options?: ExtractOptions
      ): Promise<ExtractResult>
    No global state; the API key is stored as a private readonly field.
 
-5. Retry with exponential backoff — On HTTP 429 or any 5xx status, wait 2 000 ms
+5. Retry with exponential backoff — On HTTP 5xx or 504 status, wait 2 000 ms
    before retry 1, 4 000 ms before retry 2, 8 000 ms before retry 3.
    Throw ScaleDownError after all three retries are exhausted.
-   Throw ScaleDownError immediately on 400 or 401 (not retriable).
+   Throw ScaleDownError immediately on 422 (not retriable).
 
 6. Use fetch (Node 18+ built-in). No external HTTP dependencies. Full type annotations.
 ```
@@ -150,7 +177,9 @@ ScaleDown API details:
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<document or passage to search>",
+      "text": "<document or passage to search>",    // optional if document is provided
+      "document": "<base64-encoded file>",          // optional; image or PDF
+      "document_mime_type": "image/jpeg",           // required when document is set
       "entities": {
         "<TypeName>": "<description string>"
           | { "description": str, "threshold": float, "top_n": int }
@@ -158,15 +187,18 @@ ScaleDown API details:
       "threshold": 0.5,  // optional, global confidence cutoff, default 0.5
       "top_n": 0         // optional, max results per type, 0 = unlimited, default 0
     }
+  Either "text" or "document" must be provided.
 - Success response (JSON):
     {
       "entities": [
         { "text": str, "type": str, "confidence": float,
           "start": int, "end": int, "context": str }
-      ]
+      ],
+      "structured_result": dict | None,
+      "ocr_text": str | None
     }
-- Error responses: 400 (bad body or empty entities map), 401 (invalid key),
-  429 (rate limit), 500 (server error)
+- Error responses: 422 (bad body, neither text nor document, or OCR failure),
+  500 (server error), 504 (timeout)
 
 Requirements:
 
@@ -176,21 +208,25 @@ Requirements:
 2. Tool metadata — Set:
      name = "extract_entities"
      description = a clear sentence explaining that the tool extracts named entities
-       from text using a plain-English schema, and describing the expected input format.
+       from text (or a base64-encoded document) using a plain-English schema, and
+       describing the expected input format.
 
 3. Input format — The tool's _run method accepts a single JSON string with keys:
      {
-       "text": str,                         // required
+       "text": str,                         // optional if document is provided
+       "document": str,                     // optional base64-encoded file
+       "document_mime_type": str,           // required when document is set
        "entities": { "TypeName": "desc" },  // required
        "threshold": float,                  // optional, default 0.5
        "top_n": int                         // optional, default 0
      }
    Parse it with json.loads; return a JSON error string if parsing fails.
 
-4. Return format — Return a JSON-encoded string of the entities array on success.
-   On any API error (network failure, non-2xx status, unexpected response shape),
-   return a JSON string { "error": "<message>" } rather than raising an exception,
-   so the agent can handle the failure gracefully.
+4. Return format — Return a JSON-encoded string of the full response (entities,
+   structured_result, ocr_text) on success. On any API error (network failure,
+   non-2xx status, unexpected response shape), return a JSON string
+   { "error": "<message>" } rather than raising an exception, so the agent can
+   handle the failure gracefully.
 
 5. Async version — Implement _arun as an async version of _run using aiohttp.
    Reuse the same request-building and response-parsing logic.

--- a/api-reference/integrate-summarize.mdx
+++ b/api-reference/integrate-summarize.mdx
@@ -3,10 +3,6 @@ title: "Integrate Summarize"
 description: "Copy-paste AI prompts to generate integration code for the /summarization/abstractive endpoint."
 ---
 
-<Note>
-  **Summarize is currently in private preview.** [Request access](https://app.reclaim.ai/m/neal-scaledown/25-min) before integrating.
-</Note>
-
 Copy one of these prompts into Claude, ChatGPT, or any AI assistant to generate integration code for the `/summarization/abstractive` endpoint. Start with the **quick integration** prompt to get something working fast, or use the **production-ready** prompt if you're building for a live environment.
 
 ## Prompts
@@ -16,7 +12,7 @@ Copy one of these prompts into Claude, ChatGPT, or any AI assistant to generate 
 Paste this prompt to generate a minimal Python function — useful for prototyping or one-off scripts.
 
 ```text Quick integration prompt
-Write a Python function `summarize_text(text: str, api_key: str,
+Write a Python function `summarize_text(payload: dict, api_key: str,
 instructions: str = None) -> str` that calls the ScaleDown abstractive
 summarization API and returns the summary string.
 
@@ -25,10 +21,14 @@ API details:
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<the document or passage to summarize>",
-      "instructions": "<optional extra rules>",  // optional field
-      "max_tokens": 20048                         // optional field, default 20048
+      "text": "<the document or passage to summarize>",  // optional if document is provided
+      "document": "<base64-encoded file>",               // optional; image or PDF
+      "document_mime_type": "image/jpeg",                // required when document is set
+      "instructions": "<optional extra rules>",          // optional field
+      "max_tokens": 20048                                // optional field, default 20048
     }
+  Either "text" or "document" must be provided. If both are given, OCR text is appended
+  after the plain text before summarization.
   The "instructions" field is appended to the base faithful-summary behaviour —
   it extends, not replaces, the default. Examples:
     "Use bullet points."
@@ -40,14 +40,17 @@ API details:
       "summary": "<the generated summary>",
       "input_chars": 8340,
       "output_chars": 142,
-      "latency_ms": 3241
+      "latency_ms": 3241,
+      "ocr_text": null    // populated when a document was processed
     }
-- Error responses: 400 (bad request), 401 (invalid key), 429 (rate limited),
-  500 (server error)
+- Error responses: 422 (malformed body, neither text nor document, or OCR failure),
+  500 (server error), 504 (timeout)
 
 Requirements:
+- The payload parameter is a dict that may contain "text", "document", and
+  "document_mime_type" keys. Pass it through to the request body.
 - Accept the API key as the second parameter.
-- Omit "instructions" from the request body if it is None.
+- Add "instructions" to the request body only if it is not None.
 - Raise a ValueError with a descriptive message on any non-2xx HTTP response,
   including the status code and response body in the message.
 - Return the `summary` string on success.
@@ -66,10 +69,14 @@ API details:
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<the document or passage to summarize>",
+      "text": "<the document or passage to summarize>",  // optional if document is provided
+      "document": "<base64-encoded file>",               // optional; image or PDF
+      "document_mime_type": "application/pdf",           // required when document is set
       "instructions": "<optional rules appended to base behaviour>",  // optional
       "max_tokens": 20048                                              // optional, default 20048
     }
+  Either "text" or "document" must be provided. If both are given, the OCR text is
+  appended after the plain text before summarization.
   The "instructions" field extends (not replaces) the default faithful-summary
   behaviour. It does not allow the model to add new information or commentary.
   Example values: "Use bullet points.", "Focus on dates and key decisions only.",
@@ -79,10 +86,11 @@ API details:
       "summary": "<generated summary>",
       "input_chars": 8340,
       "output_chars": 142,
-      "latency_ms": 3241
+      "latency_ms": 3241,
+      "ocr_text": "<raw OCR text>" | null    // populated when a document was processed
     }
-- Error responses: 400 (malformed body or missing text field), 401 (missing/invalid key),
-  429 (rate limit exceeded), 500 (server error)
+- Error responses: 422 (malformed body, neither text nor document, or OCR failure),
+  500 (server error), 504 (timeout)
 
 Apply these programming principles:
 
@@ -91,7 +99,8 @@ Apply these programming principles:
    or empty, with a message that tells the developer exactly which variable to set.
 
 2. Typed result — Define a SummaryResult dataclass with fields:
-     summary (str), input_chars (int), output_chars (int), latency_ms (int)
+     summary (str), input_chars (int), output_chars (int), latency_ms (int),
+     ocr_text (str | None)
 
 3. Custom exception — Define a ScaleDownError exception class that carries
    status_code (int) and message (str), and formats them into the exception message.
@@ -99,18 +108,19 @@ Apply these programming principles:
 4. Single-responsibility client — Implement a ScaleDownSummarizer class with one
    public method:
      summarize(
-       text: str,
+       text: str | None = None,
+       document: str | None = None,
+       document_mime_type: str | None = None,
        instructions: str | None = None,
        max_tokens: int | None = None
      ) -> SummaryResult
    The class owns the requests.Session and sets the auth header once at __init__.
-   Omit "instructions" and "max_tokens" from the request payload when they are None,
-   rather than sending null values.
+   Omit optional fields from the request payload when they are None.
 
-5. Retry with exponential backoff — Inside summarize(), on HTTP 429 or any 5xx status,
+5. Retry with exponential backoff — Inside summarize(), on HTTP 5xx or 504 status,
    wait 2 s before retry 1, 4 s before retry 2, 8 s before retry 3.
    Raise ScaleDownError after all three retries are exhausted.
-   Raise ScaleDownError immediately on 400 or 401 (not retriable).
+   Raise ScaleDownError immediately on 422 (not retriable).
 
 6. Type annotations — Add full type annotations to all functions, methods, and fields.
    No module-level mutable state.
@@ -121,36 +131,45 @@ Apply these programming principles:
 Paste this prompt to generate an async batch summarizer that processes many documents concurrently with controlled parallelism.
 
 ```text Async batch pipeline prompt
-Write a Python async module that batch-summarizes a list of documents using the
-ScaleDown abstractive summarization API with controlled concurrency.
+Write a Python async module that batch-summarizes a list of texts or documents using
+the ScaleDown abstractive summarization API with controlled concurrency.
 
 ScaleDown API details:
 - Endpoint: POST https://api.scaledown.xyz/summarization/abstractive
 - Auth: HTTP header `x-api-key: <your key>`
 - Request body (JSON):
     {
-      "text": "<the document or passage to summarize>",
+      "text": "<the document or passage to summarize>",  // optional if document is provided
+      "document": "<base64-encoded file>",               // optional; image or PDF
+      "document_mime_type": "application/pdf",           // required when document is set
       "instructions": "<optional rules appended to base behaviour>",  // optional
       "max_tokens": 20048                                              // optional
     }
+  Either "text" or "document" must be provided.
   "instructions" extends, not replaces, the default faithful-summary behaviour.
 - Success response (JSON):
     {
       "summary": str,
       "input_chars": int,
       "output_chars": int,
-      "latency_ms": int
+      "latency_ms": int,
+      "ocr_text": str | None
     }
-- Error responses: 400 (bad body), 401 (invalid key), 429 (rate limit), 500 (server error)
+- Error responses: 422 (bad body, neither text nor document, or OCR failure),
+  500 (server error), 504 (timeout)
 
 Requirements:
 
 1. Environment configuration — Load SCALEDOWN_API_KEY from os.environ at module load.
    Raise ValueError with a clear message if the variable is absent or empty.
 
-2. Public async function:
+2. Input type — Define a SummarizeItem dataclass with fields:
+     text (str | None), document (str | None), document_mime_type (str | None)
+   At least one of text or document must be set per item.
+
+3. Public async function:
      batch_summarize(
-       texts: list[str],
+       items: list[SummarizeItem],
        instructions: str | None = None,
        max_tokens: int | None = None,
        concurrency: int = 5
@@ -158,22 +177,23 @@ Requirements:
    Returns summaries in the same order as the input list.
    Returns None at an index if that document permanently fails after all retries.
 
-3. Concurrency control — Use asyncio + aiohttp. Limit the number of simultaneous
+4. Concurrency control — Use asyncio + aiohttp. Limit the number of simultaneous
    in-flight requests with an asyncio.Semaphore initialized to the `concurrency`
    argument.
 
-4. Per-request retry with exponential backoff — For each individual request, retry
-   up to 3 times on HTTP 429 or any 5xx status: wait 2 s, 4 s, 8 s before retries
+5. Per-request retry with exponential backoff — For each individual request, retry
+   up to 3 times on HTTP 5xx or 504 status: wait 2 s, 4 s, 8 s before retries
    1, 2, and 3. After 3 failures, store None for that index.
 
-5. Logging — Log a WARNING via the `logging` module for each document that permanently
+6. Logging — Log a WARNING via the `logging` module for each document that permanently
    fails, including its index and the final error.
 
-6. Omit optional fields — Do not include "instructions" or "max_tokens" in the
-   request payload when they are None.
+7. Omit optional fields — Do not include "instructions", "max_tokens", "document", or
+   "document_mime_type" in the request payload when they are None.
 
-7. Entry point — Include an `if __name__ == "__main__":` block that calls
-   batch_summarize on a sample list of three short strings and prints each summary.
+8. Entry point — Include an `if __name__ == "__main__":` block that calls
+   batch_summarize on a sample list of three SummarizeItem objects (text-only) and
+   prints each summary.
 ```
 
 ---
@@ -202,6 +222,7 @@ class SummaryResult:
     input_chars: int
     output_chars: int
     latency_ms: int
+    ocr_text: str | None
 
 
 class ScaleDownError(Exception):
@@ -226,11 +247,19 @@ class ScaleDownSummarizer:
 
     def summarize(
         self,
-        text: str,
+        text: str | None = None,
+        document: str | None = None,
+        document_mime_type: str | None = None,
         instructions: Optional[str] = None,
         max_tokens: Optional[int] = None,
     ) -> SummaryResult:
-        payload: dict = {"text": text}
+        payload: dict = {}
+        if text is not None:
+            payload["text"] = text
+        if document is not None:
+            payload["document"] = document
+        if document_mime_type is not None:
+            payload["document_mime_type"] = document_mime_type
         if instructions is not None:
             payload["instructions"] = instructions
         if max_tokens is not None:
@@ -252,13 +281,14 @@ class ScaleDownSummarizer:
                     input_chars=data["input_chars"],
                     output_chars=data["output_chars"],
                     latency_ms=data["latency_ms"],
+                    ocr_text=data.get("ocr_text"),
                 )
 
-            if response.status_code in {429, 500, 502, 503, 504}:
+            if response.status_code in {500, 502, 503, 504}:
                 last_error = ScaleDownError(response.status_code, response.text)
                 continue  # retry
 
-            # 400, 401: not retriable
+            # 422: not retriable
             raise ScaleDownError(response.status_code, response.text)
 
         raise last_error  # type: ignore[misc]
@@ -278,6 +308,7 @@ result = summarizer.summarize(
 )
 print(result.summary)
 print(f"Compressed {result.input_chars} chars to {result.output_chars} chars")
+# result.ocr_text is None when no document was provided
 ```
 
 </Expandable>

--- a/api-reference/summarize-overview.mdx
+++ b/api-reference/summarize-overview.mdx
@@ -3,10 +3,6 @@ title: "Summarize"
 description: "Generate fluent, faithful summaries of long text."
 ---
 
-<Note>
-  **Summarize is currently in private preview.** Access is available by invitation. To request early access or get onboarded, [contact us](https://app.reclaim.ai/m/neal-scaledown/25-min).
-</Note>
-
 ## What it does
 
 The `/summarization/abstractive` endpoint condenses text into a shorter, fluent rewrite in the model's own words. Unlike extractive summarization — which lifts sentences directly from the source — abstractive summarization produces a coherent output that captures the key information without being constrained to the original phrasing.

--- a/api-reference/summarize.mdx
+++ b/api-reference/summarize.mdx
@@ -10,8 +10,16 @@ The `/summarization/abstractive` endpoint condenses text in the model's own word
 
 ## Request
 
-<ParamField body="text" type="string" required>
-  The input text to summarize. Can be an article, document, transcript, or any plain text string.
+<ParamField body="text" type="string">
+  The input text to summarize. Can be an article, document, transcript, or any plain text string. Either `text` or `document` must be provided. If both are given, the OCR text is appended after `text`.
+</ParamField>
+
+<ParamField body="document" type="string">
+  A base64-encoded file to summarize. Supported formats: JPEG, PNG, TIFF, single-page PDF, multi-page PDF. The file is processed via AWS Textract OCR and the extracted text is used as input. Either `text` or `document` must be provided.
+</ParamField>
+
+<ParamField body="document_mime_type" type="string">
+  MIME type of the document (e.g. `"image/jpeg"`, `"application/pdf"`). Required when `document` is provided.
 </ParamField>
 
 <ParamField body="instructions" type="string">
@@ -46,14 +54,17 @@ The `/summarization/abstractive` endpoint condenses text in the model's own word
   End-to-end request latency in milliseconds.
 </ResponseField>
 
+<ResponseField name="ocr_text" type="string | null">
+  The raw text extracted from the document via OCR. `null` if no `document` was provided.
+</ResponseField>
+
 ## Error responses
 
 | Status | Meaning |
 |--------|---------|
-| `400 Bad Request` | Malformed request body or missing required fields. |
-| `401 Unauthorized` | Missing or invalid `x-api-key`. |
-| `429 Too Many Requests` | Rate limit exceeded. Back off and retry. |
+| `422 Unprocessable Entity` | Malformed request body, neither `text` nor `document` provided, or OCR failed. |
 | `500 Internal Server Error` | Inference service unavailable. |
+| `504 Gateway Timeout` | Summarization request timed out. |
 
 ## Authentication
 
@@ -184,6 +195,83 @@ const data = await response.json();
   "latency_ms": 3241
 }
 ```
+
+### Summarizing a document
+
+Pass a base64-encoded image or PDF in the `document` field. The OCR text is extracted automatically and summarized. The raw OCR output is returned as `ocr_text`.
+
+<CodeGroup>
+
+```bash cURL
+DOCUMENT=$(base64 -b 0 -i report.pdf)
+
+curl -X POST https://api.scaledown.xyz/summarization/abstractive \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "document": "'"$DOCUMENT"'",
+    "document_mime_type": "application/pdf",
+    "instructions": "Use bullet points. Focus on key figures and decisions only."
+  }'
+```
+
+```python Python
+import base64
+import requests
+
+with open("report.pdf", "rb") as f:
+    document = base64.b64encode(f.read()).decode()
+
+response = requests.post(
+    "https://api.scaledown.xyz/summarization/abstractive",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "document": document,
+        "document_mime_type": "application/pdf",
+        "instructions": "Use bullet points. Focus on key figures and decisions only.",
+    },
+)
+print(response.json())
+```
+
+```typescript TypeScript
+import fs from "fs";
+
+const document = fs.readFileSync("report.pdf").toString("base64");
+
+const response = await fetch(
+  "https://api.scaledown.xyz/summarization/abstractive",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "<your-api-key>",
+    },
+    body: JSON.stringify({
+      document,
+      document_mime_type: "application/pdf",
+      instructions: "Use bullet points. Focus on key figures and decisions only.",
+    }),
+  }
+);
+const data = await response.json();
+```
+
+</CodeGroup>
+
+**Response:**
+
+```json
+{
+  "summary": "- Q3 revenue reached $4.2B, up 12% year-over-year.\n- Board approved a $500M share buyback program.\n- CEO announced Southeast Asian expansion by mid-2027.",
+  "input_chars": 12480,
+  "output_chars": 178,
+  "latency_ms": 4103,
+  "ocr_text": "Q3 2024 Earnings Report\nRevenue: $4.2 billion (+12% YoY)\n..."
+}
+```
+
+---
 
 ## Notes
 


### PR DESCRIPTION
…ve preview labels

- Add document/document_mime_type params and ocr_text response field to classify, extract, and summarize endpoint docs
- Add structured (nested object and array) extraction docs to extract endpoint
- Remove 'private preview' notes from all model docs
- Fix error codes to match actual API (422/500/504 instead of 400/401/429/500)
- Update all integrate-*.mdx prompts to reflect new document input, ocr_text, and structured_result fields with corrected error handling guidance