### PR TITLE
Docs: add instruction field to extract, fix summarize max_tokens default

### DIFF
--- a/api-reference/extract.mdx
+++ b/api-reference/extract.mdx
@@ -24,6 +24,10 @@ Every result includes up to 500 characters of surrounding text on each side, so 
   MIME type of the document (e.g. `"image/jpeg"`, `"application/pdf"`). Required when `document` is provided.
 </ParamField>
 
+<ParamField body="instruction" type="string">
+  Optional global instruction prepended to the text before extraction. Use this to provide rules that apply across all entity types — for example, deduplication logic, ranking constraints, or output format requirements. This is separate from per-entity descriptions.
+</ParamField>
+
 <ParamField body="entities" type="object" required>
   A mapping of entity type names to their definition. Each value can be one of:
 

--- a/api-reference/integrate-extract.mdx
+++ b/api-reference/integrate-extract.mdx
@@ -23,6 +23,7 @@ API details:
       "text": "<the document or passage to search>",       // optional if document is provided
       "document": "<base64-encoded file>",                 // optional; image or PDF
       "document_mime_type": "image/jpeg",                  // required when document is set
+      "instruction": "<optional global instruction>",      // optional; prepended before the text
       "entities": {
         "<EntityTypeName>": "<plain English description of what to look for>"
         // values can also be nested objects or arrays — see structured extraction below
@@ -31,6 +32,8 @@ API details:
   Either "text" or "document" must be provided. If both are given, OCR text is appended
   after the plain text before extraction. The keys in "entities" are names you choose
   (e.g. "Name", "Email", "Company"). The values are descriptions of what each key should match.
+  The optional "instruction" field is prepended before the text and applies globally across
+  all entity types — use it for deduplication rules, ranking constraints, or output format requirements.
 - Success response (JSON):
     {
       "entities": [
@@ -82,6 +85,7 @@ API details:
       "text": "<document or passage to search>",          // optional if document is provided
       "document": "<base64-encoded file>",                // optional; image or PDF
       "document_mime_type": "application/pdf",            // required when document is set
+      "instruction": "<optional global instruction>",     // optional; prepended before the text
       "entities": {
         "<TypeName>": "<description string>"
           | {
@@ -96,7 +100,8 @@ API details:
       "top_n": 0         // optional global max results per type, default 0 (unlimited)
     }
   Either "text" or "document" must be provided. If both are given, the OCR text is
-  appended after the plain text before extraction.
+  appended after the plain text before extraction. The optional "instruction" field is
+  prepended before the text and applies globally across all entity types.
 - Success response (JSON):
     {
       "entities": [

--- a/api-reference/summarize.mdx
+++ b/api-reference/summarize.mdx
@@ -32,7 +32,7 @@ The `/summarization/abstractive` endpoint condenses text in the model's own word
   - `"Limit to 3 sentences."`
 </ParamField>
 
-<ParamField body="max_tokens" type="number" default={20048}>
+<ParamField body="max_tokens" type="number" default={2048}>
   Maximum number of tokens in the generated summary.
 </ParamField>
 


### PR DESCRIPTION
- Document new `instruction` field on /extract request (prepended before text, applies globally across all entity types)
- Add instruction to both quick and production-ready integrate-extract prompts
- Fix summarize max_tokens default from 20048 to 2048