### PR TITLE
docs(extract): image OCR walkthrough + overview coverage

### DIFF
--- a/api-reference/extract-overview.mdx
+++ b/api-reference/extract-overview.mdx
@@ -19,6 +19,8 @@ This makes it practical to extract domain-specific entities that generic NER mod
 
 **You want context alongside every result.** Every extracted span comes with 500 characters of surrounding text on each side, so you can verify the extraction in context without going back to the source document.
 
+**Your source is an image or scan, not text.** Extract has built-in OCR (AWS Textract). Send a base64-encoded photo, scan, or PDF in the `document` field and it recovers the text before extraction - so receipts, invoices, IDs, business cards, and scanned forms work without a separate OCR step. See [Extracting from an image (OCR)](/api-reference/extract#extracting-from-an-image-ocr).
+
 ## Common use cases
 
 | Use case | Example entities |
@@ -30,6 +32,7 @@ This makes it practical to extract domain-specific entities that generic NER mod
 | Customer support tickets | Product names, error codes, account identifiers |
 | News / media monitoring | People, organizations, locations, quoted statements |
 | E-commerce | Product names, prices, SKUs, brands, specifications |
+| Scanned images & receipts (OCR) | Merchant, total, date, line items, tax from a photo or scan |
 
 ## How it fits into your workflow
 

--- a/api-reference/extract.mdx
+++ b/api-reference/extract.mdx
@@ -200,9 +200,104 @@ const data = await response.json();
 }
 ```
 
-### Extracting from a document
+### Extracting from an image (OCR)
 
-Pass a base64-encoded image or PDF in the `document` field. OCR is performed automatically and the extracted text is used as the input. The raw OCR output is returned as `ocr_text`.
+Extract works directly on photos and scans, not just plain text. Pass a base64-encoded **image** (or PDF) in the `document` field - we run OCR via AWS Textract, then extract your entities from the recovered text. This is the path to use for receipts, invoices, IDs, forms, business cards, and any photographed or scanned page. The raw OCR output is returned as `ocr_text` so you can audit exactly what the model read.
+
+<Tip>
+  Supported formats: **JPEG, PNG, TIFF**, and single- or multi-page **PDF**. `document_mime_type` is required whenever `document` is set - use the file's real MIME type (e.g. `image/jpeg`, `image/png`, `application/pdf`) so Textract decodes the bytes correctly. You can also send `text` and `document` together; the OCR output is appended after your `text`.
+</Tip>
+
+The example below extracts fields from a photographed receipt:
+
+<CodeGroup>
+
+```bash cURL
+DOCUMENT=$(base64 -b 0 -i receipt.jpg)
+
+curl -X POST https://api.scaledown.xyz/extract \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <your-api-key>" \
+  -d '{
+    "document": "'"$DOCUMENT"'",
+    "document_mime_type": "image/jpeg",
+    "entities": {
+      "merchant": "Name of the store or merchant",
+      "total": "Total amount paid, including currency",
+      "date": "Date of the transaction"
+    }
+  }'
+```
+
+```python Python
+import base64
+import requests
+
+with open("receipt.jpg", "rb") as f:
+    document = base64.b64encode(f.read()).decode()
+
+response = requests.post(
+    "https://api.scaledown.xyz/extract",
+    headers={"x-api-key": "<your-api-key>"},
+    json={
+        "document": document,
+        "document_mime_type": "image/jpeg",
+        "entities": {
+            "merchant": "Name of the store or merchant",
+            "total": "Total amount paid, including currency",
+            "date": "Date of the transaction",
+        },
+    },
+)
+data = response.json()
+print(data["entities"])
+print(data["ocr_text"])  # raw text recovered from the image
+```
+
+```typescript TypeScript
+import fs from "fs";
+
+const document = fs.readFileSync("receipt.jpg").toString("base64");
+
+const response = await fetch("https://api.scaledown.xyz/extract", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-api-key": "<your-api-key>",
+  },
+  body: JSON.stringify({
+    document,
+    document_mime_type: "image/jpeg",
+    entities: {
+      merchant: "Name of the store or merchant",
+      total: "Total amount paid, including currency",
+      date: "Date of the transaction",
+    },
+  }),
+});
+const data = await response.json();
+console.log(data.ocr_text); // raw text recovered from the image
+```
+
+</CodeGroup>
+
+**Response:**
+
+```json
+{
+  "entities": [
+    { "text": "Blue Bottle Coffee", "type": "merchant", "confidence": 0.98, "start": 0, "end": 18, "context": "Blue Bottle Coffee ..." },
+    { "text": "$12.50", "type": "total", "confidence": 0.95, "start": 38, "end": 44, "context": "... TOTAL $12.50" },
+    { "text": "03/14/2026", "type": "date", "confidence": 0.97, "start": 19, "end": 29, "context": "Blue Bottle Coffee 03/14/2026 ..." }
+  ],
+  "structured_result": null,
+  "ocr_text": "Blue Bottle Coffee\n03/14/2026\n1x Latte  $5.00\n1x Croissant  $7.50\nTOTAL $12.50"
+}
+```
+
+### Extracting from a PDF
+
+PDFs (single- or multi-page) work the same way - just set `document_mime_type` to `application/pdf`.
 
 <CodeGroup>
 


### PR DESCRIPTION
Customers are using Extract for **OCR on images**. The docs already documented `document` / `document_mime_type` / `ocr_text`, but the only worked example was a PDF (with no response shown), and image support was buried in a comparison-table row.

## Changes

**`api-reference/extract.mdx`**
- New **"Extracting from an image (OCR)"** section: JPEG receipt example (cURL / Python / TS) **with a response showing `ocr_text` populated** (the document example previously had no response).
- A `<Tip>` listing supported formats (JPEG, PNG, TIFF, PDF) and the `document_mime_type` requirement.
- Existing PDF example retained as **"Extracting from a PDF"**.

**`api-reference/extract-overview.mdx`**
- New "Your source is an image or scan" *when to use it* entry.
- New scanned-images/receipts row in the use-case table.
- Both link to the new section.

Companion feature PR in `scaledown-team/scaledown-playground` adds image upload to the Extract playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)